### PR TITLE
Fix: Update CSS to Hide Error Messages

### DIFF
--- a/stylesheets/SimpliGov-basic.css
+++ b/stylesheets/SimpliGov-basic.css
@@ -133,7 +133,7 @@ div#workflow-background-wrapper {
 }
 
 /* Hide field value */
-#element108, #element123, #element138, #element180 {
+#element108, #element123, #element138, #form-element-wrapper_180 {
 	display: none;
 	padding: 10px!important;
 }

--- a/stylesheets/SimpliGov-basic.css
+++ b/stylesheets/SimpliGov-basic.css
@@ -133,7 +133,7 @@ div#workflow-background-wrapper {
 }
 
 /* Hide field value */
-#element108, #element123, #element138, #form-element-wrapper_180 {
+#element108, #element123, #element138, #element180, #element183 {
 	display: none;
 	padding: 10px!important;
 }
@@ -148,3 +148,9 @@ div#workflow-background-wrapper {
 	margin: -10px 0px;
 }
 
+/* Hide error fields */
+#form-element-wrapper_108, #form-element-wrapper_180, #form-element-wrapper_183 {
+    visibility: hidden;
+    height: 0px;
+    margin: -20px 0px;
+}

--- a/stylesheets/SimpliGov-basic.css
+++ b/stylesheets/SimpliGov-basic.css
@@ -133,7 +133,7 @@ div#workflow-background-wrapper {
 }
 
 /* Hide field value */
-#element108, #element123, #element138, #element180, #element183 {
+#element108, #element123, #element138, #element180, #element183, #element184 {
 	display: none;
 	padding: 10px!important;
 }
@@ -149,7 +149,7 @@ div#workflow-background-wrapper {
 }
 
 /* Hide error fields */
-#form-element-wrapper_108, #form-element-wrapper_180, #form-element-wrapper_183 {
+#form-element-wrapper_108, #form-element-wrapper_180, #form-element-wrapper_183, #form-element-wrapper_184 {
     visibility: hidden;
     height: 0px;
     margin: -20px 0px;

--- a/stylesheets/SimpliGov-basic.css
+++ b/stylesheets/SimpliGov-basic.css
@@ -133,7 +133,7 @@ div#workflow-background-wrapper {
 }
 
 /* Hide field value */
-#element108, #element123, #element138 {
+#element108, #element123, #element138, #element180 {
 	display: none;
 	padding: 10px!important;
 }


### PR DESCRIPTION
Per the linked Asana ticket below, we need to hide the standard SimpliGov error messages and replace them with custom HTML error elements. This fix updates the SimpliGov stylesheet to hide these standard error messages. 

Asana ticket: https://app.asana.com/0/1170867711449497/1200718287617956/f