### PR TITLE
Fix: Update Cypress script to match eligibility checker tab changes

### DIFF
--- a/cypress/automated-tests/youth-pass/successful-youth-pass-submission.spec.js
+++ b/cypress/automated-tests/youth-pass/successful-youth-pass-submission.spec.js
@@ -17,45 +17,47 @@ describe('Youth Pass Successful Submission', () => {
         cy.get('#form-section-0 > .form-section-buttons > .form-section-next').click();
         cy.get('#element105').type(applicantZipCode).blur();
         cy.get('#element15').type(applicantBirthdate).blur();
-        cy.get('#element164_Option_1').click().blur();
         cy.get('#form-section-1 > .form-section-buttons > .form-section-next').click();
+        
+        cy.get('#element164_Option_1').click().blur();
+        cy.get('#form-section-3 > .form-section-buttons > .form-section-next').click();
         
         cy.get('#element116_Option_1').click().blur();
         cy.get('#element11').type(applicantFirstName).blur();
         cy.get('#element13').type(applicantLastName).blur();
-        cy.get('#form-section-2 > .form-section-buttons > .form-section-next').click();
+        cy.get('#form-section-4 > .form-section-buttons > .form-section-next').click();
         
         cy.get('#element17').type(applicantPhoneNumber).blur();
         cy.get('#element18').type(applicantEmailAddress).blur();
-        cy.get('#form-section-3 > .form-section-buttons > .form-section-next').click();
+        cy.get('#form-section-5 > .form-section-buttons > .form-section-next').click();
                 
         cy.get('#element101').type(applicantStreetAddress).blur();
         cy.get('#element103').type(applicantCity).blur();
         cy.get('#element154').type(applicantZipCode).blur();
         cy.get('#element122_Option_1').click().blur();
-        cy.get('#form-section-4 > .form-section-buttons > .form-section-next').click();
+        cy.get('#form-section-6 > .form-section-buttons > .form-section-next').click();
         
         cy.get('#element114_Option_1').click().blur();
         cy.get('#element133').attachFile('youth-pass-test-image.png')
         cy.get('.k-file-validation-message').should('exist');
-        cy.get('#form-section-5 > .form-section-buttons > .form-section-next').click();
+        cy.get('#form-section-7 > .form-section-buttons > .form-section-next').click();
         
         cy.get('#element135_Option_1').click().blur();
         cy.get('#element39').attachFile('youth-pass-test-image.png')
         cy.get('.k-file-validation-message').should('exist');
-        cy.get('#form-section-6 > .form-section-buttons > .form-section-next').click();
+        cy.get('#form-section-8 > .form-section-buttons > .form-section-next').click();
         
         cy.get('#element41_Option_1').click().blur();
         cy.get('#element42').select('Child Care (DTA, EEC)', { force: true });
         cy.get('#element136').attachFile('youth-pass-test-image.png')
         cy.get('.k-file-validation-message').should('exist');
-        cy.get('#form-section-7 > .form-section-buttons > .form-section-next').click();
+        cy.get('#form-section-9 > .form-section-buttons > .form-section-next').click();
         
         cy.get('#element52_Option_2').click().blur();
-        cy.get('#form-section-8 > .form-section-buttons > .form-section-next').click();
+        cy.get('#form-section-10 > .form-section-buttons > .form-section-next').click();
         
         cy.get('#element50').click().blur();
-        cy.get('#form-section-9 > .form-section-buttons > .form-submit-button').click();
+        cy.get('#form-section-11 > .form-section-buttons > .form-submit-button').click();
 
         cy.get('#thank-you-text').should('contain', 'Application Submitted')
         cy.get('#thank-you-text').should('contain', 'mbtayouthpass@boston.gov')


### PR DESCRIPTION
We've updated the Eligibility Checker to reduce the complexity of progressive disclosure logic. This logic occasionally caused bugs during user testing and QA. 

This PR updates the successful submission Cypress script to match these changes. Test stats following this update:
- 20/20 runs completed 
- 20/20 runs passed

[Asana ticket here](https://app.asana.com/0/1170867711449497/1200989929457797/f) for the Eligibility Checker updates. No corresponding Cypress update ticket.