### PR TITLE
Feat: Add training data source with test admin accounts

### DIFF
--- a/data_sources/PreProd Department Permissions Data Source.csv
+++ b/data_sources/PreProd Department Permissions Data Source.csv
@@ -1,121 +1,121 @@
-﻿Zip,Municipality,Group Admin One,Group Admin Two,Group Admin Three
-02474,Arlington,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,
-02475,Arlington,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,
-02476,Arlington,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,
-02108,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com
-02109,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com
-02110,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com
-02111,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com
-02112,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com
-02113,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com
-02114,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com
-02115,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com
-02116,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com
-02117,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com
-02118,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com
-02119,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com
-02120,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com
-02121,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com
-02122,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com
-02123,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com
-02124,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com
-02125,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com
-02126,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com
-02127,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com
-02128,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com
-02129,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com
-02130,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com
-02131,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com
-02132,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com
-02133,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com
-02134,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com
-02135,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com
-02136,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com
-02137,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com
-02163,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com
-02196,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com
-02199,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com
-02201,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com
-02203,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com
-02204,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com
-02205,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com
-02206,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com
-02210,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com
-02211,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com
-02212,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com
-02215,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com
-02217,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com
-02222,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com
-02241,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com
-02283,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com
-02284,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com
-02293,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com
-02297,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com
-02298,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com
-02445,Brookline,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,krisjohnson+m5@mbta.com
-02446,Brookline,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,krisjohnson+m5@mbta.com
-02447,Brookline,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,krisjohnson+m5@mbta.com
-02138,Cambridge,Test1@mbta.com,Test2@mbta.com,Test3@mbta.com
-02139,Cambridge,Test1@mbta.com,Test2@mbta.com,Test3@mbta.com
-02140,Cambridge,Test1@mbta.com,Test2@mbta.com,Test3@mbta.com
-02141,Cambridge,Test1@mbta.com,Test2@mbta.com,Test3@mbta.com
-02142,Cambridge,Test1@mbta.com,Test2@mbta.com,Test3@mbta.com
-02238,Cambridge,Test1@mbta.com,Test2@mbta.com,Test3@mbta.com
-02150,Chelsea,krisjohnson+m5@mbta.com,,
-02149,Everett,krisjohnson+m1@mbta.com,,
-02420,Lexington,krisjohnson+m7@mbta.com,krisjohnson+m8@mbta.com,
-02421,Lexington,krisjohnson+m7@mbta.com,krisjohnson+m8@mbta.com,
-02148,Malden,Test4@mbta.com,,
-02153,Medford,krisjohnson+m1@mbta.com,krisjohnson+m2@mbta.com,krisjohnson+m7@mbta.com
-02155,Medford,krisjohnson+m1@mbta.com,krisjohnson+m2@mbta.com,krisjohnson+m7@mbta.com
-02156,Medford,krisjohnson+m1@mbta.com,krisjohnson+m2@mbta.com,krisjohnson+m7@mbta.com
-01833,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,
-01834,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,
-01860,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,
-01885,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,
-01901,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,
-01902,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,
-01903,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,
-01904,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,
-01905,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,
-01906,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,
-01907,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,
-01908,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,
-01910,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,
-01915,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,
-01921,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,
-01922,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,
-01923,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,
-01929,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,
-01930,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,
-01931,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,
-01936,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,
-01938,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,
-01940,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,
-01944,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,
-01945,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,
-01949,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,
-01950,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,
-01951,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,
-01952,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,
-01960,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,
-01961,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,
-01966,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,
-01969,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,
-01970,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,
-01971,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,
-01983,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,
-01984,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,
-01985,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,
-02169,Quincy,Test5@mbta.com,krisjohnson+m8@mbta.com,krisjohnson+m4@mbta.com
-02170,Quincy,Test5@mbta.com,krisjohnson+m8@mbta.com,krisjohnson+m4@mbta.com
-02171,Quincy,Test5@mbta.com,krisjohnson+m8@mbta.com,krisjohnson+m4@mbta.com
-02269,Quincy,Test5@mbta.com,krisjohnson+m8@mbta.com,krisjohnson+m4@mbta.com
-02151,Revere,krisjohnson+m5@mbta.com,krisjohnson+m6@mbta.com,
-02143,Somerville,krisjohnson+m3@mbta.com,,
-02144,Somerville,krisjohnson+m3@mbta.com,,
-02145,Somerville,krisjohnson+m3@mbta.com,,
-01880,Wakefield,krisjohnson+m1@mbta.com,krisjohnson+m2@mbta.com,
-02471,Watertown,krisjohnson+m7@mbta.com,krisjohnson+m8@mbta.com,
-02472,Watertown,krisjohnson+m7@mbta.com,krisjohnson+m8@mbta.com,
-02477,Watertown,krisjohnson+m7@mbta.com,krisjohnson+m8@mbta.com,
+﻿Zip,Municipality,Group Admin One,Group Admin Two,Group Admin Three,Group Admin Four,Group Admin Five
+02474,Arlington,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,,,
+02475,Arlington,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,,,
+02476,Arlington,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,,,
+02108,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com,,
+02109,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com,,
+02110,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com,,
+02111,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com,,
+02112,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com,,
+02113,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com,,
+02114,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com,,
+02115,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com,,
+02116,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com,,
+02117,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com,,
+02118,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com,,
+02119,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com,,
+02120,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com,,
+02121,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com,,
+02122,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com,,
+02123,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com,,
+02124,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com,,
+02125,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com,,
+02126,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com,,
+02127,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com,,
+02128,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com,,
+02129,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com,,
+02130,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com,,
+02131,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com,,
+02132,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com,,
+02133,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com,,
+02134,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com,,
+02135,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com,,
+02136,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com,,
+02137,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com,,
+02163,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com,,
+02196,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com,,
+02199,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com,,
+02201,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com,,
+02203,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com,,
+02204,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com,,
+02205,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com,,
+02206,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com,,
+02210,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com,,
+02211,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com,,
+02212,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com,,
+02215,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com,,
+02217,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com,,
+02222,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com,,
+02241,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com,,
+02283,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com,,
+02284,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com,,
+02293,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com,,
+02297,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com,,
+02298,Boston,test6@mbta.com,krisjohnson+m7@mbta.com,krisjohnson+m2@mbta.com,,
+02445,Brookline,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,krisjohnson+m5@mbta.com,,
+02446,Brookline,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,krisjohnson+m5@mbta.com,,
+02447,Brookline,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,krisjohnson+m5@mbta.com,,
+02138,Cambridge,Test1@mbta.com,Test2@mbta.com,Test3@mbta.com,,
+02139,Cambridge,Test1@mbta.com,Test2@mbta.com,Test3@mbta.com,,
+02140,Cambridge,Test1@mbta.com,Test2@mbta.com,Test3@mbta.com,,
+02141,Cambridge,Test1@mbta.com,Test2@mbta.com,Test3@mbta.com,,
+02142,Cambridge,Test1@mbta.com,Test2@mbta.com,Test3@mbta.com,,
+02238,Cambridge,Test1@mbta.com,Test2@mbta.com,Test3@mbta.com,,
+02150,Chelsea,krisjohnson+m5@mbta.com,,,,
+02149,Everett,krisjohnson+m1@mbta.com,,,,
+02420,Lexington,krisjohnson+m7@mbta.com,krisjohnson+m8@mbta.com,,,
+02421,Lexington,krisjohnson+m7@mbta.com,krisjohnson+m8@mbta.com,,,
+02148,Malden,Test4@mbta.com,,,,
+02153,Medford,krisjohnson+m1@mbta.com,krisjohnson+m2@mbta.com,krisjohnson+m7@mbta.com,,
+02155,Medford,krisjohnson+m1@mbta.com,krisjohnson+m2@mbta.com,krisjohnson+m7@mbta.com,,
+02156,Medford,krisjohnson+m1@mbta.com,krisjohnson+m2@mbta.com,krisjohnson+m7@mbta.com,,
+01833,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,,,
+01834,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,,,
+01860,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,,,
+01885,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,,,
+01901,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,,,
+01902,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,,,
+01903,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,,,
+01904,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,,,
+01905,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,,,
+01906,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,,,
+01907,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,,,
+01908,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,,,
+01910,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,,,
+01915,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,,,
+01921,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,,,
+01922,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,,,
+01923,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,,,
+01929,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,,,
+01930,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,,,
+01931,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,,,
+01936,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,,,
+01938,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,,,
+01940,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,,,
+01944,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,,,
+01945,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,,,
+01949,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,,,
+01950,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,,,
+01951,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,,,
+01952,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,,,
+01960,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,,,
+01961,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,,,
+01966,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,,,
+01969,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,,,
+01970,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,,,
+01971,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,,,
+01983,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,,,
+01984,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,,,
+01985,North Shore,krisjohnson+m3@mbta.com,krisjohnson+m4@mbta.com,,,
+02169,Quincy,Test5@mbta.com,krisjohnson+m8@mbta.com,krisjohnson+m4@mbta.com,,
+02170,Quincy,Test5@mbta.com,krisjohnson+m8@mbta.com,krisjohnson+m4@mbta.com,,
+02171,Quincy,Test5@mbta.com,krisjohnson+m8@mbta.com,krisjohnson+m4@mbta.com,,
+02269,Quincy,Test5@mbta.com,krisjohnson+m8@mbta.com,krisjohnson+m4@mbta.com,,
+02151,Revere,krisjohnson+m5@mbta.com,krisjohnson+m6@mbta.com,,,
+02143,Somerville,krisjohnson+m3@mbta.com,,,,
+02144,Somerville,krisjohnson+m3@mbta.com,,,,
+02145,Somerville,krisjohnson+m3@mbta.com,,,,
+01880,Wakefield,krisjohnson+m1@mbta.com,krisjohnson+m2@mbta.com,,,
+02471,Watertown,krisjohnson+m7@mbta.com,krisjohnson+m8@mbta.com,,,
+02472,Watertown,krisjohnson+m7@mbta.com,krisjohnson+m8@mbta.com,,,
+02477,Watertown,krisjohnson+m7@mbta.com,krisjohnson+m8@mbta.com,,,

--- a/data_sources/Training Department Permissions Data Source.csv
+++ b/data_sources/Training Department Permissions Data Source.csv
@@ -1,0 +1,121 @@
+﻿Zip,Municipality,Group Admin One,Group Admin Two,Group Admin Three
+02474,Arlington,sbarlingtontest@mbta.com,klarlingtontest@mbta.com,noarlingtontest@mbta.com
+02475,Arlington,sbarlingtontest@mbta.com,klarlingtontest@mbta.com,noarlingtontest@mbta.com
+02476,Arlington,sbarlingtontest@mbta.com,klarlingtontest@mbta.com,noarlingtontest@mbta.com
+02108,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
+02109,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
+02110,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
+02111,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
+02112,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
+02113,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
+02114,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
+02115,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
+02116,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
+02117,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
+02118,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
+02119,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
+02120,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
+02121,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
+02122,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
+02123,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
+02124,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
+02125,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
+02126,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
+02127,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
+02128,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
+02129,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
+02130,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
+02131,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
+02132,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
+02133,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
+02134,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
+02135,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
+02136,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
+02137,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
+02163,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
+02196,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
+02199,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
+02201,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
+02203,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
+02204,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
+02205,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
+02206,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
+02210,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
+02211,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
+02212,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
+02215,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
+02217,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
+02222,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
+02241,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
+02283,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
+02284,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
+02293,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
+02297,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
+02298,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
+02445,Brookline,rgbrooklinetest@mbta.com,tkbrooklinetest@mbta.com,
+02446,Brookline,rgbrooklinetest@mbta.com,tkbrooklinetest@mbta.com,
+02447,Brookline,rgbrooklinetest@mbta.com,tkbrooklinetest@mbta.com,
+02138,Cambridge,smcambridgetest@mbta.com,gkcambridgetest@mbta.com,
+02139,Cambridge,smcambridgetest@mbta.com,gkcambridgetest@mbta.com,
+02140,Cambridge,smcambridgetest@mbta.com,gkcambridgetest@mbta.com,
+02141,Cambridge,smcambridgetest@mbta.com,gkcambridgetest@mbta.com,
+02142,Cambridge,smcambridgetest@mbta.com,gkcambridgetest@mbta.com,
+02238,Cambridge,smcambridgetest@mbta.com,gkcambridgetest@mbta.com,
+02150,Chelsea,onchelseatest@mbta.com,,
+02149,Everett,mceveretttest@mbta.com,,
+02420,Lexington,sblexingtontest@mbta.com,mnlexingtontest@mbta.com,
+02421,Lexington,sblexingtontest@mbta.com,mnlexingtontest@mbta.com,
+02148,Malden,esmaldentest@mbta.com,,
+02153,Medford,wpmedfordtest@mbta.com,jjmedfordtest@mbta.com,mhmedfordtest@mbta.com
+02155,Medford,wpmedfordtest@mbta.com,jjmedfordtest@mbta.com,mhmedfordtest@mbta.com
+02156,Medford,wpmedfordtest@mbta.com,jjmedfordtest@mbta.com,mhmedfordtest@mbta.com
+01833,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
+01834,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
+01860,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
+01885,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
+01901,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
+01902,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
+01903,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
+01904,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
+01905,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
+01906,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
+01907,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
+01908,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
+01910,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
+01915,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
+01921,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
+01922,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
+01923,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
+01929,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
+01930,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
+01931,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
+01936,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
+01938,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
+01940,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
+01944,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
+01945,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
+01949,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
+01950,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
+01951,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
+01952,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
+01960,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
+01961,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
+01966,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
+01969,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
+01970,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
+01971,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
+01983,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
+01984,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
+01985,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
+02169,Quincy,thquincytest@mbta.com,wmquincytest@mbta.com,hmquincytest@mbta.com
+02170,Quincy,thquincytest@mbta.com,wmquincytest@mbta.com,hmquincytest@mbta.com
+02171,Quincy,thquincytest@mbta.com,wmquincytest@mbta.com,hmquincytest@mbta.com
+02269,Quincy,thquincytest@mbta.com,wmquincytest@mbta.com,hmquincytest@mbta.com
+02151,Revere,spreveretest@mbta.com,rcreveretest@mbta.com,
+02143,Somerville,nbsomervilletest@mbta.com,jttsomervilletest@mbta.com,
+02144,Somerville,nbsomervilletest@mbta.com,jttsomervilletest@mbta.com,
+02145,Somerville,nbsomervilletest@mbta.com,jttsomervilletest@mbta.com,
+01880,Wakefield,sdwakefieldtest@mbta.com,smwakefieldtest@mbta.com,
+02471,Watertown,ssfwatertowntest@mbta.com,mrwatertowntest@mbta.com,
+02472,Watertown,ssfwatertowntest@mbta.com,mrwatertowntest@mbta.com,
+02477,Watertown,ssfwatertowntest@mbta.com,mrwatertowntest@mbta.com,

--- a/data_sources/Training Department Permissions Data Source.csv
+++ b/data_sources/Training Department Permissions Data Source.csv
@@ -1,121 +1,121 @@
-﻿Zip,Municipality,Group Admin One,Group Admin Two,Group Admin Three
-02474,Arlington,sbarlingtontest@mbta.com,klarlingtontest@mbta.com,noarlingtontest@mbta.com
-02475,Arlington,sbarlingtontest@mbta.com,klarlingtontest@mbta.com,noarlingtontest@mbta.com
-02476,Arlington,sbarlingtontest@mbta.com,klarlingtontest@mbta.com,noarlingtontest@mbta.com
-02108,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
-02109,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
-02110,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
-02111,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
-02112,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
-02113,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
-02114,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
-02115,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
-02116,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
-02117,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
-02118,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
-02119,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
-02120,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
-02121,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
-02122,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
-02123,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
-02124,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
-02125,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
-02126,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
-02127,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
-02128,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
-02129,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
-02130,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
-02131,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
-02132,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
-02133,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
-02134,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
-02135,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
-02136,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
-02137,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
-02163,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
-02196,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
-02199,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
-02201,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
-02203,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
-02204,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
-02205,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
-02206,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
-02210,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
-02211,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
-02212,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
-02215,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
-02217,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
-02222,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
-02241,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
-02283,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
-02284,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
-02293,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
-02297,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
-02298,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com
-02445,Brookline,rgbrooklinetest@mbta.com,tkbrooklinetest@mbta.com,
-02446,Brookline,rgbrooklinetest@mbta.com,tkbrooklinetest@mbta.com,
-02447,Brookline,rgbrooklinetest@mbta.com,tkbrooklinetest@mbta.com,
-02138,Cambridge,smcambridgetest@mbta.com,gkcambridgetest@mbta.com,
-02139,Cambridge,smcambridgetest@mbta.com,gkcambridgetest@mbta.com,
-02140,Cambridge,smcambridgetest@mbta.com,gkcambridgetest@mbta.com,
-02141,Cambridge,smcambridgetest@mbta.com,gkcambridgetest@mbta.com,
-02142,Cambridge,smcambridgetest@mbta.com,gkcambridgetest@mbta.com,
-02238,Cambridge,smcambridgetest@mbta.com,gkcambridgetest@mbta.com,
-02150,Chelsea,onchelseatest@mbta.com,,
-02149,Everett,mceveretttest@mbta.com,,
-02420,Lexington,sblexingtontest@mbta.com,mnlexingtontest@mbta.com,
-02421,Lexington,sblexingtontest@mbta.com,mnlexingtontest@mbta.com,
-02148,Malden,esmaldentest@mbta.com,,
-02153,Medford,wpmedfordtest@mbta.com,jjmedfordtest@mbta.com,mhmedfordtest@mbta.com
-02155,Medford,wpmedfordtest@mbta.com,jjmedfordtest@mbta.com,mhmedfordtest@mbta.com
-02156,Medford,wpmedfordtest@mbta.com,jjmedfordtest@mbta.com,mhmedfordtest@mbta.com
-01833,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
-01834,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
-01860,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
-01885,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
-01901,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
-01902,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
-01903,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
-01904,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
-01905,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
-01906,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
-01907,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
-01908,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
-01910,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
-01915,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
-01921,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
-01922,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
-01923,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
-01929,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
-01930,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
-01931,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
-01936,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
-01938,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
-01940,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
-01944,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
-01945,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
-01949,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
-01950,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
-01951,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
-01952,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
-01960,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
-01961,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
-01966,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
-01969,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
-01970,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
-01971,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
-01983,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
-01984,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
-01985,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,
-02169,Quincy,thquincytest@mbta.com,wmquincytest@mbta.com,hmquincytest@mbta.com
-02170,Quincy,thquincytest@mbta.com,wmquincytest@mbta.com,hmquincytest@mbta.com
-02171,Quincy,thquincytest@mbta.com,wmquincytest@mbta.com,hmquincytest@mbta.com
-02269,Quincy,thquincytest@mbta.com,wmquincytest@mbta.com,hmquincytest@mbta.com
-02151,Revere,spreveretest@mbta.com,rcreveretest@mbta.com,
-02143,Somerville,nbsomervilletest@mbta.com,jttsomervilletest@mbta.com,
-02144,Somerville,nbsomervilletest@mbta.com,jttsomervilletest@mbta.com,
-02145,Somerville,nbsomervilletest@mbta.com,jttsomervilletest@mbta.com,
-01880,Wakefield,sdwakefieldtest@mbta.com,smwakefieldtest@mbta.com,
-02471,Watertown,ssfwatertowntest@mbta.com,mrwatertowntest@mbta.com,
-02472,Watertown,ssfwatertowntest@mbta.com,mrwatertowntest@mbta.com,
-02477,Watertown,ssfwatertowntest@mbta.com,mrwatertowntest@mbta.com,
+﻿Zip,Municipality,Group Admin One,Group Admin Two,Group Admin Three,Group Admin Four,Group Admin Five
+02474,Arlington,sbarlingtontest@mbta.com,klarlingtontest@mbta.com,noarlingtontest@mbta.com,,
+02475,Arlington,sbarlingtontest@mbta.com,klarlingtontest@mbta.com,noarlingtontest@mbta.com,,
+02476,Arlington,sbarlingtontest@mbta.com,klarlingtontest@mbta.com,noarlingtontest@mbta.com,,
+02108,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com,ajbostontest@mbta.com,
+02109,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com,ajbostontest@mbta.com,
+02110,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com,ajbostontest@mbta.com,
+02111,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com,ajbostontest@mbta.com,
+02112,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com,ajbostontest@mbta.com,
+02113,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com,ajbostontest@mbta.com,
+02114,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com,ajbostontest@mbta.com,
+02115,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com,ajbostontest@mbta.com,
+02116,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com,ajbostontest@mbta.com,
+02117,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com,ajbostontest@mbta.com,
+02118,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com,ajbostontest@mbta.com,
+02119,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com,ajbostontest@mbta.com,
+02120,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com,ajbostontest@mbta.com,
+02121,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com,ajbostontest@mbta.com,
+02122,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com,ajbostontest@mbta.com,
+02123,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com,ajbostontest@mbta.com,
+02124,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com,ajbostontest@mbta.com,
+02125,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com,ajbostontest@mbta.com,
+02126,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com,ajbostontest@mbta.com,
+02127,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com,ajbostontest@mbta.com,
+02128,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com,ajbostontest@mbta.com,
+02129,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com,ajbostontest@mbta.com,
+02130,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com,ajbostontest@mbta.com,
+02131,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com,ajbostontest@mbta.com,
+02132,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com,ajbostontest@mbta.com,
+02133,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com,ajbostontest@mbta.com,
+02134,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com,ajbostontest@mbta.com,
+02135,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com,ajbostontest@mbta.com,
+02136,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com,ajbostontest@mbta.com,
+02137,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com,ajbostontest@mbta.com,
+02163,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com,ajbostontest@mbta.com,
+02196,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com,ajbostontest@mbta.com,
+02199,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com,ajbostontest@mbta.com,
+02201,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com,ajbostontest@mbta.com,
+02203,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com,ajbostontest@mbta.com,
+02204,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com,ajbostontest@mbta.com,
+02205,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com,ajbostontest@mbta.com,
+02206,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com,ajbostontest@mbta.com,
+02210,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com,ajbostontest@mbta.com,
+02211,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com,ajbostontest@mbta.com,
+02212,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com,ajbostontest@mbta.com,
+02215,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com,ajbostontest@mbta.com,
+02217,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com,ajbostontest@mbta.com,
+02222,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com,ajbostontest@mbta.com,
+02241,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com,ajbostontest@mbta.com,
+02283,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com,ajbostontest@mbta.com,
+02284,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com,ajbostontest@mbta.com,
+02293,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com,ajbostontest@mbta.com,
+02297,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com,ajbostontest@mbta.com,
+02298,Boston,dbbostontest@mbta.com,crbostontest@mbta.com,jkabostontest@mbta.com,ajbostontest@mbta.com,
+02445,Brookline,rgbrooklinetest@mbta.com,tkbrooklinetest@mbta.com,,,
+02446,Brookline,rgbrooklinetest@mbta.com,tkbrooklinetest@mbta.com,,,
+02447,Brookline,rgbrooklinetest@mbta.com,tkbrooklinetest@mbta.com,,,
+02138,Cambridge,smcambridgetest@mbta.com,gkcambridgetest@mbta.com,,,
+02139,Cambridge,smcambridgetest@mbta.com,gkcambridgetest@mbta.com,,,
+02140,Cambridge,smcambridgetest@mbta.com,gkcambridgetest@mbta.com,,,
+02141,Cambridge,smcambridgetest@mbta.com,gkcambridgetest@mbta.com,,,
+02142,Cambridge,smcambridgetest@mbta.com,gkcambridgetest@mbta.com,,,
+02238,Cambridge,smcambridgetest@mbta.com,gkcambridgetest@mbta.com,,,
+02150,Chelsea,onchelseatest@mbta.com,,,,
+02149,Everett,mceveretttest@mbta.com,,,,
+02420,Lexington,sblexingtontest@mbta.com,mnlexingtontest@mbta.com,,,
+02421,Lexington,sblexingtontest@mbta.com,mnlexingtontest@mbta.com,,,
+02148,Malden,esmaldentest@mbta.com,,,,
+02153,Medford,wpmedfordtest@mbta.com,jjmedfordtest@mbta.com,mhmedfordtest@mbta.com,,
+02155,Medford,wpmedfordtest@mbta.com,jjmedfordtest@mbta.com,mhmedfordtest@mbta.com,,
+02156,Medford,wpmedfordtest@mbta.com,jjmedfordtest@mbta.com,mhmedfordtest@mbta.com,,
+01833,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,,,
+01834,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,,,
+01860,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,,,
+01885,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,,,
+01901,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,,,
+01902,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,,,
+01903,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,,,
+01904,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,,,
+01905,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,,,
+01906,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,,,
+01907,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,,,
+01908,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,,,
+01910,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,,,
+01915,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,,,
+01921,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,,,
+01922,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,,,
+01923,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,,,
+01929,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,,,
+01930,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,,,
+01931,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,,,
+01936,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,,,
+01938,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,,,
+01940,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,,,
+01944,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,,,
+01945,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,,,
+01949,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,,,
+01950,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,,,
+01951,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,,,
+01952,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,,,
+01960,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,,,
+01961,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,,,
+01966,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,,,
+01969,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,,,
+01970,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,,,
+01971,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,,,
+01983,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,,,
+01984,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,,,
+01985,North Shore,aanorthshoretest@mbta.com,cnnorthshoretest@mbta.com,,,
+02169,Quincy,thquincytest@mbta.com,wmquincytest@mbta.com,hmquincytest@mbta.com,,
+02170,Quincy,thquincytest@mbta.com,wmquincytest@mbta.com,hmquincytest@mbta.com,,
+02171,Quincy,thquincytest@mbta.com,wmquincytest@mbta.com,hmquincytest@mbta.com,,
+02269,Quincy,thquincytest@mbta.com,wmquincytest@mbta.com,hmquincytest@mbta.com,,
+02151,Revere,spreveretest@mbta.com,rcreveretest@mbta.com,,,
+02143,Somerville,nbsomervilletest@mbta.com,jttsomervilletest@mbta.com,,,
+02144,Somerville,nbsomervilletest@mbta.com,jttsomervilletest@mbta.com,,,
+02145,Somerville,nbsomervilletest@mbta.com,jttsomervilletest@mbta.com,,,
+01880,Wakefield,sdwakefieldtest@mbta.com,smwakefieldtest@mbta.com,,,
+02471,Watertown,ssfwatertowntest@mbta.com,mrwatertowntest@mbta.com,,,
+02472,Watertown,ssfwatertowntest@mbta.com,mrwatertowntest@mbta.com,,,
+02477,Watertown,ssfwatertowntest@mbta.com,mrwatertowntest@mbta.com,,,


### PR DESCRIPTION
In advance of Administrator training on 9/23, we created accounts in training for Administrator testing purposes. This PR creates a data source for the SimpliGov Training environment which maps these training accounts to zip codes. 

Asana ticket: https://app.asana.com/0/1170867711449497/1200984533102007/f