### PR TITLE
Feat: Personal and Contact Info Required Fields Cypress Script

### DIFF
--- a/cypress/automated-tests/youth-pass/address-section-required-fields.spec.js
+++ b/cypress/automated-tests/youth-pass/address-section-required-fields.spec.js
@@ -1,6 +1,6 @@
 const faker = require('faker');
 
-describe('Youth Pass Address Section', () => {
+describe('Youth Pass Address Section Required Fields', () => {
     it('proceeds through an application', () => {
         const applicantZipCode = '02114';
         const youthPassUrl = Cypress.env('youth_pass_url');

--- a/cypress/automated-tests/youth-pass/personal-contact-sections-required-fields.spec.js
+++ b/cypress/automated-tests/youth-pass/personal-contact-sections-required-fields.spec.js
@@ -1,0 +1,98 @@
+const faker = require('faker');
+
+describe('Youth Pass Personal and Contact Info Section Required Fields', () => {
+    it('proceeds through an application', () => {
+        const applicantZipCode = '02114';
+        const youthPassUrl = Cypress.env('youth_pass_url');
+        const randomBirthdate = faker.date.between('1996-11-01', '2004-10-31');
+        const applicantBirthdate = `${randomBirthdate.getMonth() + 1}/${randomBirthdate.getDate()}/${randomBirthdate.getFullYear()}`;
+        
+        cy.visit(youthPassUrl);
+        cy.get('#form-section-0 > .form-section-buttons > .form-section-next').click();
+        cy.get('#element105').type(applicantZipCode).blur();
+        cy.get('#element15').type(applicantBirthdate).blur();
+        cy.get('#form-section-1 > .form-section-buttons > .form-section-next').click();
+        
+        cy.get('#element164_Option_1').click().blur();
+        cy.get('#form-section-3 > .form-section-buttons > .form-section-next').click();
+    });
+    
+    it('does not fill any personal info fields and sees required field errors', () => {              
+        cy.get('#form-section-4 > .form-section-buttons > .form-submit-button').click();
+        cy.get('#form-element-wrapper_116').within(() => {
+            cy.get('div.required-text').should('be.visible');
+        });
+        cy.get('#form-element-wrapper_11').within(() => {
+            cy.get('div.required-text').should('be.visible');
+        });
+        cy.get('#form-element-wrapper_13').within(() => {
+            cy.get('div.required-text').should('be.visible');
+        });
+    });
+    
+    it('only fills application options radio and sees required field errors', () => {              
+        cy.get('#element116_Option_1').click().blur();
+        cy.get('#form-section-4 > .form-section-buttons > .form-submit-button').click();
+        cy.get('#form-element-wrapper_116').within(() => {
+            cy.get('div.required-text').should('not.be.visible');
+        });
+        cy.get('#form-element-wrapper_11').within(() => {
+            cy.get('div.required-text').should('be.visible');
+        });
+        cy.get('#form-element-wrapper_13').within(() => {
+            cy.get('div.required-text').should('be.visible');
+        });          
+    });
+    
+    it('does not fill last name and sees required field errors', () => {              
+        const applicantFirstName = faker.name.firstName();
+
+        cy.get('#element11').type(applicantFirstName).blur();
+        cy.get('#form-section-4 > .form-section-buttons > .form-submit-button').click();
+        cy.get('#form-element-wrapper_11').within(() => {
+            cy.get('div.required-text').should('not.be.visible');
+        });
+        cy.get('#form-element-wrapper_13').within(() => {
+            cy.get('div.required-text').should('be.visible');
+        });
+    });   
+        
+    it('fills all personal info fields and sees no required field errors', () => {                    
+        const applicantLastName = faker.name.lastName();
+
+        cy.get('#element13').type(applicantLastName).blur();
+        cy.get('div.required-text').should('not.be.visible');
+        cy.get('#form-section-4 > .form-section-buttons > .form-section-next').click();
+    });
+    
+    it('does not fill any contact info fields and sees required field errors', () => {              
+        cy.get('#form-section-5 > .form-section-buttons > .form-submit-button').click();
+        cy.get('#form-element-wrapper_17').within(() => {
+            cy.get('div.required-text').should('be.visible');
+        });
+        cy.get('#form-element-wrapper_18').within(() => {
+            cy.get('div.required-text').should('be.visible');
+        });
+    });
+    
+    it('only fills phone number and sees required field errors', () => {              
+        const applicantPhoneNumber = faker.phone.phoneNumber();
+
+        cy.get('#element17').type(applicantPhoneNumber).blur();
+        cy.get('#form-section-5 > .form-section-buttons > .form-submit-button').click();
+        cy.get('#form-element-wrapper_17').within(() => {
+            cy.get('div.required-text').should('not.be.visible');
+        });
+        cy.get('#form-element-wrapper_18').within(() => {
+            cy.get('div.required-text').should('be.visible');
+        });          
+    });
+    
+        
+    it('fills all contact info fields and sees no required field errors', () => {                    
+        const applicantEmailAddress = `Automation_Testing_${faker.datatype.number()}@example.com`;
+        
+        cy.get('#element18').type(applicantEmailAddress).blur();
+        cy.get('div.required-text').should('not.be.visible');
+    });
+});


### PR DESCRIPTION
This PR adds an automation script testing the Personal Information and Contact Information sections of the Youth Pass application. 

The script tests that all required fields on both of these sections perform as expected, showing errors when an applicant does not fill out a field and hiding errors when applicants complete the field.

Asana ticket: https://app.asana.com/0/1170867711449497/1200759639068400/f