### PR TITLE
Feat: Add Cypress Scripts and Remove Videos

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -1,6 +1,7 @@
 {
     "integrationFolder": "cypress/automated-tests",
     "defaultCommandTimeout": 10000,
+    "video": false,
     "env": {
         "youth_pass_url": "https://mbta.preprod.simpligov.com/preprod/portal/ShowWorkFlow/AnonymousEmbed/86cadfa6-e8ea-46f1-b6e8-62498f066962"
     }

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "cypress:open": "cypress open",
-    "cypress:run": "cypress run"
+    "cypress:local": "cypress open",
+    "cypress:ci": "cypress run"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "version": "1.0.0",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "cypress:open": "cypress open",
+    "cypress:run": "cypress run"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
This PR adds scripts to `open` the Cypress automation tool locally and `run` all automation scripts headless. It also updates the Cypress `config` file to no longer record/store videos of test runs, as this is not a desired feature within the Reduced Fares project.

Asana ticket: https://app.asana.com/0/1170867711449497/1201050482135214/f