### PR TITLE
Feat: Update successful submission test to use 99999 zip code

### DIFF
--- a/cypress/automated-tests/youth-pass/successful-youth-pass-submission.spec.js
+++ b/cypress/automated-tests/youth-pass/successful-youth-pass-submission.spec.js
@@ -1,7 +1,7 @@
 const faker = require('faker');
 
 describe('Youth Pass Successful Submission', () => {
-    const applicantZipCode = '02114';
+    const applicantZipCode = '99999';
     
     it('completes the eligibility checker', () => {
         const youthPassUrl = Cypress.env('youth_pass_url');
@@ -78,7 +78,7 @@ describe('Youth Pass Successful Submission', () => {
         cy.get('#form-section-11 > .form-section-buttons > .form-submit-button').click();
 
         cy.get('#thank-you-text', { timeout: 15000 }).should('contain', 'Application Submitted')
-        cy.get('#thank-you-text', { timeout: 15000 }).should('contain', 'mbtayouthpass@boston.gov')
+        cy.get('#thank-you-text', { timeout: 15000 }).should('contain', 'ebalkam@mbta.com')
     });
 });
 


### PR DESCRIPTION
Now that the Youth Pass application accepts 99999 as a valid zip code, this PR updates the successful submission Cypress script to use this zip code and assert against the revised Thank You page. 

Asana ticket: https://app.asana.com/0/1170867711449497/1201050482135206/f