### PR TITLE
Feat: Run Cypress tests nightly against pre-production

### DIFF
--- a/.github/workflows/automation.yml
+++ b/.github/workflows/automation.yml
@@ -6,4 +6,3 @@ jobs:
     steps:
       - name: Integration tests / Cypress
         uses: cypress-io/github-action@v2
-        run: cypress:ci

--- a/.github/workflows/automation.yml
+++ b/.github/workflows/automation.yml
@@ -1,10 +1,10 @@
 name: Automation
 on:
   schedule:
-    - cron: '0 16 * * *' # run at 4 AM UTC/12 AM EST
+    - cron: '0 15 * * *' # run at 4 AM UTC/12 AM EST
 jobs:
   cypress:
     runs-on: ubuntu-latest
     steps:
       - name: Integration tests / Cypress
-        run: npm run cypress:ci
+        uses: cypress-io/github-action@v2

--- a/.github/workflows/automation.yml
+++ b/.github/workflows/automation.yml
@@ -1,10 +1,9 @@
 name: Automation
-on:
-  schedule:
-    - cron: '0 15 * * *' # run at 4 AM UTC/12 AM EST
+on: [push]
 jobs:
   cypress:
     runs-on: ubuntu-latest
     steps:
       - name: Integration tests / Cypress
         uses: cypress-io/github-action@v2
+        run: cypress:ci

--- a/.github/workflows/automation.yml
+++ b/.github/workflows/automation.yml
@@ -8,4 +8,4 @@ jobs:
     name: Integration tests / Cypress
     runs-on: ubuntu-latest
     steps:
-      - run: npx run cypress:ci
+      - run: npm run cypress:ci

--- a/.github/workflows/automation.yml
+++ b/.github/workflows/automation.yml
@@ -1,0 +1,11 @@
+name: Automation
+on:
+  schedule:
+    - cron: '0 4 * * *' # run at 4 AM UTC/12 AM EST
+
+cypress:
+  name: Integration tests / Cypress
+  runs-on: ubuntu-latest
+  steps:
+    - uses: cypress-io/github-action@v2
+      run: npm run ci:integration:cypress

--- a/.github/workflows/automation.yml
+++ b/.github/workflows/automation.yml
@@ -1,11 +1,11 @@
 name: Automation
 on:
   schedule:
-    - cron: '0 16 * * *' # run at 4 AM UTC/12 AM EST
+    - cron: '0 4 * * *' # run at 4 AM UTC/12 AM EST
 
 jobs:
   cypress:
     name: Integration tests / Cypress
     runs-on: ubuntu-latest
     steps:
-      - run: npm run cypress:ci
+      - run: npx run cypress:ci

--- a/.github/workflows/automation.yml
+++ b/.github/workflows/automation.yml
@@ -8,5 +8,4 @@ jobs:
     name: Integration tests / Cypress
     runs-on: ubuntu-latest
     steps:
-      - uses: cypress-io/github-action@v2
         run: npm run cypress:ci

--- a/.github/workflows/automation.yml
+++ b/.github/workflows/automation.yml
@@ -8,5 +8,4 @@ jobs:
     name: Integration tests / Cypress
     runs-on: ubuntu-latest
     steps:
-      - uses: cypress-io/github-action@v2
       - run: npm run cypress:ci

--- a/.github/workflows/automation.yml
+++ b/.github/workflows/automation.yml
@@ -7,4 +7,4 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Integration tests / Cypress
-        run: cypress:ci
+        run: npm run cypress:ci

--- a/.github/workflows/automation.yml
+++ b/.github/workflows/automation.yml
@@ -7,4 +7,4 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Integration tests / Cypress
-        run: npm run cypress:ci
+        uses: cypress-io/github-action@v2

--- a/.github/workflows/automation.yml
+++ b/.github/workflows/automation.yml
@@ -7,4 +7,4 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Integration tests / Cypress
-        uses: cypress-io/github-action@v2
+        run: cypress:ci

--- a/.github/workflows/automation.yml
+++ b/.github/workflows/automation.yml
@@ -1,7 +1,7 @@
 name: Automation
 on:
   schedule:
-    - cron: '0 4 * * *' # run at 4 AM UTC/12 AM EST
+    - cron: '0 16 * * *' # run at 4 AM UTC/12 AM EST
 
 jobs:
   cypress:

--- a/.github/workflows/automation.yml
+++ b/.github/workflows/automation.yml
@@ -2,10 +2,9 @@ name: Automation
 on:
   schedule:
     - cron: '0 16 * * *' # run at 4 AM UTC/12 AM EST
-
 jobs:
   cypress:
-    name: Integration tests / Cypress
     runs-on: ubuntu-latest
     steps:
-      - run: npm run cypress:ci
+      - name: Integration tests / Cypress
+        run: npm run cypress:ci

--- a/.github/workflows/automation.yml
+++ b/.github/workflows/automation.yml
@@ -4,5 +4,7 @@ jobs:
   cypress:
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2
       - name: Integration tests / Cypress
         uses: cypress-io/github-action@v2

--- a/.github/workflows/automation.yml
+++ b/.github/workflows/automation.yml
@@ -1,5 +1,7 @@
 name: Automation
-on: [push]
+on: 
+  schedule:
+    - cron: '0 4 * * *' # run at 4 AM UTC/12 AM EST
 jobs:
   cypress:
     runs-on: ubuntu-latest

--- a/.github/workflows/automation.yml
+++ b/.github/workflows/automation.yml
@@ -1,11 +1,12 @@
 name: Automation
 on:
   schedule:
-    - cron: '15 16 * * *' # run at 4 AM UTC/12 AM EST
+    - cron: '0 4 * * *' # run at 4 AM UTC/12 AM EST
 
 jobs:
   cypress:
     name: Integration tests / Cypress
     runs-on: ubuntu-latest
     steps:
-        run: npm run cypress:ci
+      - uses: cypress-io/github-action@v2
+      - run: npm run cypress:ci

--- a/.github/workflows/automation.yml
+++ b/.github/workflows/automation.yml
@@ -1,11 +1,14 @@
 name: Automation
 on:
   schedule:
-    - cron: '0 4 * * *' # run at 4 AM UTC/12 AM EST
+    - cron: '0 16 * * *' # run at 4 AM UTC/12 AM EST
 
 cypress:
   name: Integration tests / Cypress
   runs-on: ubuntu-latest
   steps:
     - uses: cypress-io/github-action@v2
-      run: npm run ci:integration:cypress
+      run: npm run cypress:ci
+      with:
+        browser: chrome
+        headless: true

--- a/.github/workflows/automation.yml
+++ b/.github/workflows/automation.yml
@@ -1,14 +1,12 @@
 name: Automation
 on:
   schedule:
-    - cron: '0 16 * * *' # run at 4 AM UTC/12 AM EST
+    - cron: '15 16 * * *' # run at 4 AM UTC/12 AM EST
 
-cypress:
-  name: Integration tests / Cypress
-  runs-on: ubuntu-latest
-  steps:
-    - uses: cypress-io/github-action@v2
-      run: npm run cypress:ci
-      with:
-        browser: chrome
-        headless: true
+jobs:
+  cypress:
+    name: Integration tests / Cypress
+    runs-on: ubuntu-latest
+    steps:
+      - uses: cypress-io/github-action@v2
+        run: npm run cypress:ci


### PR DESCRIPTION
This PR adds a workflow to run automation tests nightly against the Youth Pass pre-production environment. 

Asana ticket: https://app.asana.com/0/1170867711449497/1201050482135219/f