### PR TITLE
Fix: Remove italics from error messages

### DIFF
--- a/stylesheets/SimpliGov-basic.css
+++ b/stylesheets/SimpliGov-basic.css
@@ -382,7 +382,8 @@ h5 {
 /* Required text and regex error color */
 .required-text,
 .regexErrorLabel {
-    color: #B3000F;
+    color: #B3000F!important;
+    font-style: normal;
 }
 
 /* END Error style section */


### PR DESCRIPTION
Accessibility testing flagged that the italic font on Youth Pass field-level error messages may cause problems for screen readers or visually impaired users. 

This PR updates the Youth Pass CSS to set all field-level error messages in normal, non-italicized font.

Asana ticket: https://app.asana.com/0/1170867711449497/1200880153168112/f