### PR TITLE
Fix: Update scripts for new program enrollment screen

### DIFF
--- a/cypress/automated-tests/youth-pass/file-type-upload.spec.js
+++ b/cypress/automated-tests/youth-pass/file-type-upload.spec.js
@@ -107,7 +107,6 @@ describe('Youth Pass File Uploads', () => {
     });
 
     it('fails to upload an RTF file to proof of program enrollment', () => {
-        cy.get('#element41_Option_1').click().blur();
         cy.get('#element42').select('Child Care (DTA, EEC)', { force: true });
         cy.get('#element136').attachFile('youth-pass-test-file.rtf')
         cy.get('.k-text-error').should('exist');

--- a/cypress/automated-tests/youth-pass/successful-youth-pass-submission.spec.js
+++ b/cypress/automated-tests/youth-pass/successful-youth-pass-submission.spec.js
@@ -63,7 +63,6 @@ describe('Youth Pass Successful Submission', () => {
     });
 
     it('completes the proof of program eligiblity section', () => {
-        cy.get('#element41_Option_1').click().blur();
         cy.get('#element42').select('Child Care (DTA, EEC)', { force: true });
         cy.get('#element136').attachFile('youth-pass-test-image.png')
         cy.get('.k-text-success').should('exist');


### PR DESCRIPTION
We updated the Youth Pass program enrollment tab to simplify questions and improve our user experience. 

This PR updates the Cypress automation scripts to remove a click action on a form element that is no longer included. No other steps require changes. Both updated tests passed 10/10 runs in Cypress.

Asana ticket for program enrollment tab update: https://app.asana.com/0/1170867711449497/1200881008767723/f