### PR TITLE
Fix: Update automation run time

### DIFF
--- a/.github/workflows/automation-prod.yml
+++ b/.github/workflows/automation-prod.yml
@@ -1,7 +1,7 @@
 name: Cypress Automation Testing
 on: 
   schedule:
-    - cron: '0 4 * * *' # run at 4 AM UTC/12 AM EST
+    - cron: '0 5 * * *' # run at 5 AM UTC
 jobs:
   cypress-prod:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Daylight savings time pushed our automation run back one hour to 11 PM. This PR updates the workflow to run at either 12 AM (during daylight savings) or 1 am, reducing the likelihood of this bumping into an actual application. 

No Asana ticket. 