### PR TITLE
Fix: Update successful submission script to select card delivery preference

### DIFF
--- a/cypress/automated-tests/youth-pass/successful-youth-pass-submission.spec.js
+++ b/cypress/automated-tests/youth-pass/successful-youth-pass-submission.spec.js
@@ -41,6 +41,7 @@ describe('Youth Pass Successful Submission', () => {
         const applicantStreetAddress = `${faker.datatype.number()} ${faker.address.streetName()} ${faker.address.streetSuffix()}`;
         const applicantCity = faker.address.city();
 
+        cy.get('#element242_Option_1').click().blur();
         cy.get('#element101').type(applicantStreetAddress).blur();
         cy.get('#element103').type(applicantCity).blur();
         cy.get('#element154').type(applicantZipCode).blur();


### PR DESCRIPTION
This PR updates the Cypress `successful-submission` script to select a card delivery preference (by mail). This work is currently live in the PreProd Youth Pass form, and will be deployed to Prod on 11/18. 

Asana ticket for the front end work: https://app.asana.com/0/1170867711449497/1201303342640612/f