### PR TITLE
Fix: Update scripts with card delivery options

### DIFF
--- a/cypress/automated-tests/youth-pass/address-section-required-fields.spec.js
+++ b/cypress/automated-tests/youth-pass/address-section-required-fields.spec.js
@@ -3,6 +3,7 @@ import { getRandomApplicantAge } from '../../common/birthdate-constants';
 describe('Youth Pass Address Section Required Fields', () => {
     const faker = require('faker');
     
+    // this test follows the by mail flow
     it('proceeds through an application', () => {
         const applicantZipCode = '02114';
         const youthPassUrl = Cypress.env('youth_pass_url');
@@ -36,6 +37,29 @@ describe('Youth Pass Address Section Required Fields', () => {
     
     it('does not fill any home address fields and sees required field errors', () => {              
         cy.get('#form-section-6 > .form-section-buttons > .form-submit-button').click();
+        cy.get('#form-element-wrapper_242').within(() => {
+            cy.get('div.required-text').should('be.visible');
+        });
+        cy.get('#form-element-wrapper_101').within(() => {
+            cy.get('div.required-text').should('be.visible');
+        });
+        cy.get('#form-element-wrapper_101').within(() => {
+            cy.get('div.required-text').should('be.visible');
+        });
+        cy.get('#form-element-wrapper_103').within(() => {
+            cy.get('div.required-text').should('be.visible');
+        });
+        cy.get('#form-element-wrapper_154').within(() => {
+            cy.get('div.required-text').should('be.visible');
+        });
+    });
+    
+    it('only selects card delivery method and sees required field errors', () => {              
+        cy.get('#element242_Option_1').click().blur();
+        cy.get('#form-section-6 > .form-section-buttons > .form-submit-button').click();
+        cy.get('#form-element-wrapper_242').within(() => {
+            cy.get('div.required-text').should('not.be.visible');
+        });
         cy.get('#form-element-wrapper_101').within(() => {
             cy.get('div.required-text').should('be.visible');
         });

--- a/cypress/automated-tests/youth-pass/file-type-upload.spec.js
+++ b/cypress/automated-tests/youth-pass/file-type-upload.spec.js
@@ -3,6 +3,7 @@ import { getRandomApplicantAge } from '../../common/birthdate-constants';
 describe('Youth Pass File Uploads', () => {
     const faker = require('faker');
     
+    // this test follows the in-person false flow
     it('proceeds through an application', () => {
         const youthPassUrl = Cypress.env('youth_pass_url');
         const applicantFirstName = faker.name.firstName();
@@ -12,7 +13,7 @@ describe('Youth Pass File Uploads', () => {
         const applicantBirthdate = getRandomApplicantAge().applicantBirthdate18to25;
         const applicantStreetAddress = `${faker.datatype.number()} ${faker.address.streetName()} ${faker.address.streetSuffix()}`;
         const applicantCity = faker.address.city();
-        const applicantZipCode = '02114';
+        const applicantZipCode = '02149';
         
         cy.visit(youthPassUrl);
         cy.get('#form-section-0 > .form-section-buttons > .form-section-next').click();

--- a/cypress/automated-tests/youth-pass/successful-youth-pass-submission.spec.js
+++ b/cypress/automated-tests/youth-pass/successful-youth-pass-submission.spec.js
@@ -4,6 +4,7 @@ describe('Youth Pass Successful Submission', () => {
     const faker = require('faker');
     const applicantZipCode = '99999';
 
+    // this test follows the by-mail flow
     it('completes the eligibility checker', () => {
         const youthPassUrl = Cypress.env('youth_pass_url');
         const applicantBirthdate = getRandomApplicantAge().applicantBirthdate18to25;

--- a/cypress/automated-tests/youth-pass/successful-youth-pass-submission.spec.js
+++ b/cypress/automated-tests/youth-pass/successful-youth-pass-submission.spec.js
@@ -4,7 +4,7 @@ describe('Youth Pass Successful Submission', () => {
     const faker = require('faker');
     const applicantZipCode = '99999';
 
-    // this test follows the by-mail flow
+    // this test follows the in-person later flow
     it('completes the eligibility checker', () => {
         const youthPassUrl = Cypress.env('youth_pass_url');
         const applicantBirthdate = getRandomApplicantAge().applicantBirthdate18to25;
@@ -42,7 +42,7 @@ describe('Youth Pass Successful Submission', () => {
         const applicantStreetAddress = `${faker.datatype.number()} ${faker.address.streetName()} ${faker.address.streetSuffix()}`;
         const applicantCity = faker.address.city();
 
-        cy.get('#element242_Option_1').click().blur();
+        cy.get('#element242_Option_2').click().blur();
         cy.get('#element101').type(applicantStreetAddress).blur();
         cy.get('#element103').type(applicantCity).blur();
         cy.get('#element154').type(applicantZipCode).blur();

--- a/cypress/automated-tests/youth-pass/successful-youth-pass-submission.spec.js
+++ b/cypress/automated-tests/youth-pass/successful-youth-pass-submission.spec.js
@@ -46,7 +46,6 @@ describe('Youth Pass Successful Submission', () => {
         cy.get('#element101').type(applicantStreetAddress).blur();
         cy.get('#element103').type(applicantCity).blur();
         cy.get('#element154').type(applicantZipCode).blur();
-        cy.get('#element122_Option_1').click().blur();
         cy.get('#form-section-6 > .form-section-buttons > .form-section-next').click();
     });
 


### PR DESCRIPTION
Two Youth Pass automation scripts failed overnight due to changes in Prod. This PR updates these scripts to select a card delivery method. In the `address-section-required-fields` script, a new `it` block tests that a user is not able to progress without selecting a card delivery method. 

No Asana ticket.