### PR TITLE
Fix: Update GitHub automation workflow names

### DIFF
--- a/.github/workflows/automation-preprod.yml
+++ b/.github/workflows/automation-preprod.yml
@@ -1,4 +1,4 @@
-name: Cypress Automation Production Testing
+name: Cypress Automation PreProd Testing
 on: workflow_dispatch
 jobs:
   cypress-preprod:

--- a/.github/workflows/automation-prod.yml
+++ b/.github/workflows/automation-prod.yml
@@ -1,4 +1,4 @@
-name: Cypress Automation Testing
+name: Cypress Automation Production Testing
 on: 
   schedule:
     - cron: '0 5 * * *' # run at 5 AM UTC


### PR DESCRIPTION
While running the PreProd automation workflow manually, I noticed that it was named incorrectly. This PR updates these workflows to accurately reflect their environments. 