### PR TITLE
ci: Configure Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: "/assets"
+    schedule:
+      interval: daily
+      time: "09:00"
+    open-pull-requests-limit: 10
+    versioning-strategy: lockfile-only


### PR DESCRIPTION
Asana ticket: [Set up Dependabot on the reduced_fares repo](https://app.asana.com/0/1170867711449497/1201384476871290)

Check npm dependencies for lockfile-only updates.

I've already turned on Dependabot alerts and security updates in the
GitHub project.