### PR TITLE
Fix: Replace Chelsea group admin user

### DIFF
--- a/data_sources/Production Department Permissions Data Source.csv
+++ b/data_sources/Production Department Permissions Data Source.csv
@@ -62,7 +62,7 @@
 02141,Cambridge,smintz@cambridgema.gov,gkotowski@cambridgema.gov,,,,,,,,,tpass@cambridgema.gov
 02142,Cambridge,smintz@cambridgema.gov,gkotowski@cambridgema.gov,,,,,,,,,tpass@cambridgema.gov
 02238,Cambridge,smintz@cambridgema.gov,gkotowski@cambridgema.gov,,,,,,,,,tpass@cambridgema.gov
-02150,Chelsea,olivian@greenrootschelsea.org,layneb@greenrootschelsea.org,,,,,,,,,youthpass@greenrootschelsea.org
+02150,Chelsea,samm@greenrootschelsea.org,layneb@greenrootschelsea.org,,,,,,,,,youthpass@greenrootschelsea.org
 02149,Everett,Margaret.cornelio@ci.everett.ma.us,andrea.romboli@ci.everett.ma.us,,,,,,,,,Margaret.cornelio@ci.everett.ma.us
 01701,Framingham,troy_fernandes@waysideyouth.org,allison_parks@waysideyouth.org,Oscar_landaverde@waysideyouth.org,,,,,,,,framinghamyouthpass@waysideyouth.org
 01702,Framingham,troy_fernandes@waysideyouth.org,allison_parks@waysideyouth.org,Oscar_landaverde@waysideyouth.org,,,,,,,,framinghamyouthpass@waysideyouth.org


### PR DESCRIPTION
Chelsea is getting a new Group Admin for the Youth Pass program. This PR updates the existing data source to grant access to the incoming admin. 

Asana ticket: https://app.asana.com/0/1170867711449497/1201495675913746/f