### PR TITLE
Fix: Resolve automation birth year error

### DIFF
--- a/cypress/common/birthdate-constants.js
+++ b/cypress/common/birthdate-constants.js
@@ -1,4 +1,6 @@
-// returns a range of Youth Pass applicant ages (12-17, 18-25, too old, too young) for automation testing
+/**
+ * Return a range of Youth Pass applicant ages (12-17, 18-25, too old, too young) for automation testing
+*/
 export function getRandomApplicantAge() {
     const faker = require('faker');
     const todaysDate = new Date();
@@ -17,9 +19,11 @@ export function getRandomApplicantAge() {
     const applicantBirthdate12to17 = `${randomDate12to17.getMonth() + 1}/${randomDate12to17.getDate()}/${randomDate12to17.getFullYear()}`;    
     const applicantBirthdate18to25 = `${randomDate18to25.getMonth() + 1}/${randomDate18to25.getDate()}/${randomDate18to25.getFullYear()}`;    
     
-    // returns the year in which a Youth Pass program year begins (e.g., 2021-22 program year begins in 2021)
-    // Youth Pass eligibility and age groupings are based off a static date (e.g., 2021-22 based on Nov 1, 2021)
-    // baseline year constant is necessary to prevent false failures across Youth Pass automation caused by calendar year changeover
+    
+    /** Return the year in which a Youth Pass program year begins (e.g., 2021-22 program year begins in 2021)
+     Youth Pass eligibility and age groupings are based off a static date (e.g., 2021-22 based on Nov 1, 2021)
+     baseline year constant is necessary to prevent false failures across Youth Pass automation caused by calendar year changeover
+    */
     function getBaselineYear() {
         const todaysDate = new Date();
         let programYearStart = null;

--- a/cypress/common/birthdate-constants.js
+++ b/cypress/common/birthdate-constants.js
@@ -1,10 +1,12 @@
+// returns a range of Youth Pass applicant ages (12-17, 18-25, too old, too young) for automation testing
 export function getRandomApplicantAge() {
     const faker = require('faker');
     const todaysDate = new Date();
-    const twelveYearsAgo = todaysDate.getFullYear() - 12;
-    const eighteenYearsAgo = todaysDate.getFullYear() - 18; 
-    const twentySixYearsAgo = todaysDate.getFullYear() - 26; 
-    const fiftyYearsAgo = todaysDate.getFullYear() - 50;
+    const baselineYear = getBaselineYear();
+    const twelveYearsAgo = baselineYear - 12;
+    const eighteenYearsAgo = baselineYear - 18; 
+    const twentySixYearsAgo = baselineYear - 26; 
+    const fiftyYearsAgo = baselineYear - 50;
     const currentDate = `${todaysDate.getMonth() + 1}/${todaysDate.getDate()}/${todaysDate.getFullYear()}`;
     const randomDateTooYoung = faker.date.between(`${twelveYearsAgo}-11-02`, currentDate);
     const randomDateTooOld = faker.date.between(`${fiftyYearsAgo}-01-01`, `${twentySixYearsAgo}-11-01`);
@@ -15,5 +17,19 @@ export function getRandomApplicantAge() {
     const applicantBirthdate12to17 = `${randomDate12to17.getMonth() + 1}/${randomDate12to17.getDate()}/${randomDate12to17.getFullYear()}`;    
     const applicantBirthdate18to25 = `${randomDate18to25.getMonth() + 1}/${randomDate18to25.getDate()}/${randomDate18to25.getFullYear()}`;    
     
+    // returns the year in which a Youth Pass program year begins (e.g., 2021-22 year begins in 2021)
+    // Youth Pass eligibility and age groupings are based off a static date (e.g., 2021-22 based on Nov 1, 2021)
+    // baseline year constant is necessary to prevent false failures across Youth Pass automation caused by calendar year changeover
+    function getBaselineYear() {
+        const todaysDate = new Date();
+        let programYearStart = null;
+        if ((todaysDate.getMonth() + 1) < 10) {
+            programYearStart = todaysDate.getFullYear() - 1;
+        } else {
+            programYearStart = todaysDate.getFullYear();        
+        }
+        return programYearStart;
+    };
+
     return {applicantBirthdateTooYoung, applicantBirthdateTooOld, applicantBirthdate12to17, applicantBirthdate18to25}
 }

--- a/cypress/common/birthdate-constants.js
+++ b/cypress/common/birthdate-constants.js
@@ -17,7 +17,7 @@ export function getRandomApplicantAge() {
     const applicantBirthdate12to17 = `${randomDate12to17.getMonth() + 1}/${randomDate12to17.getDate()}/${randomDate12to17.getFullYear()}`;    
     const applicantBirthdate18to25 = `${randomDate18to25.getMonth() + 1}/${randomDate18to25.getDate()}/${randomDate18to25.getFullYear()}`;    
     
-    // returns the year in which a Youth Pass program year begins (e.g., 2021-22 year begins in 2021)
+    // returns the year in which a Youth Pass program year begins (e.g., 2021-22 program year begins in 2021)
     // Youth Pass eligibility and age groupings are based off a static date (e.g., 2021-22 based on Nov 1, 2021)
     // baseline year constant is necessary to prevent false failures across Youth Pass automation caused by calendar year changeover
     function getBaselineYear() {


### PR DESCRIPTION
Youth Pass automation scripts began randomly failing on Jan 1, 2022. Some investigation revealed the root cause of these failures is the date math done by automation scripts to calculate applicant ages. 

This PR updates this date math to use a consistent `baselineYear` variable, aligning with the start of the Youth Pass program year (e.g., the 2021-22 program year runs 10/2021 - 09/2022 and will always use 2021 as the `baselineYear`). This aligns our automation scripts with how we treat the Program Year within SimpliGov, as a consistent value based off November 1 of the current program year (e.g., 2021-22 program year uses 11/01/22 within SimpliGov).

No Asana ticket