### PR TITLE
Fix: Update automation scripts for Jan release

### DIFF
--- a/cypress/automated-tests/youth-pass/address-section-required-fields.spec.js
+++ b/cypress/automated-tests/youth-pass/address-section-required-fields.spec.js
@@ -16,27 +16,28 @@ describe('Youth Pass Address Section Required Fields', () => {
         
         cy.visit(youthPassUrl);
         cy.get('#form-section-0 > .form-section-buttons > .form-section-next').click();
+        cy.get('#form-section-1 > .form-section-buttons > .form-section-next').click();
         cy.get('#element105').type(applicantZipCode).blur();
         cy.get('#element15').type(applicantBirthdate).blur();
-        cy.get('#form-section-1 > .form-section-buttons > .form-section-next').click();
-        
-        cy.get('#element159_Option_1').click().blur();
-        cy.get('#element160_Option_2').click().blur();
-        cy.get('#element163').type(applicantSchoolName).blur();
         cy.get('#form-section-2 > .form-section-buttons > .form-section-next').click();
         
-        cy.get('#element116_Option_1').click().blur();
+        cy.get('#element159_Yes').click().blur();
+        cy.get('#element160_No').click().blur();
+        cy.get('#element163').type(applicantSchoolName).blur();
+        cy.get('#form-section-3 > .form-section-buttons > .form-section-next').click();
+        
+        cy.get('#element116_Apply').click().blur();
         cy.get('#element11').type(applicantFirstName).blur();
         cy.get('#element13').type(applicantLastName).blur();
-        cy.get('#form-section-4 > .form-section-buttons > .form-section-next').click();
+        cy.get('#form-section-5 > .form-section-buttons > .form-section-next').click();
         
         cy.get('#element17').type(applicantPhoneNumber).blur();
         cy.get('#element18').type(applicantEmailAddress).blur();
-        cy.get('#form-section-5 > .form-section-buttons > .form-section-next').click();
+        cy.get('#form-section-6 > .form-section-buttons > .form-section-next').click();
     });
     
     it('does not fill any home address fields and sees required field errors', () => {              
-        cy.get('#form-section-6 > .form-section-buttons > .form-submit-button').click();
+        cy.get('#form-section-7 > .form-section-buttons > .form-submit-button').click();
         cy.get('#form-element-wrapper_242').within(() => {
             cy.get('div.required-text').should('be.visible');
         });
@@ -55,8 +56,8 @@ describe('Youth Pass Address Section Required Fields', () => {
     });
     
     it('only selects card delivery method and sees required field errors', () => {              
-        cy.get('#element242_Option_1').click().blur();
-        cy.get('#form-section-6 > .form-section-buttons > .form-submit-button').click();
+        cy.get('#element242_Mail').click().blur();
+        cy.get('#form-section-7 > .form-section-buttons > .form-submit-button').click();
         cy.get('#form-element-wrapper_242').within(() => {
             cy.get('div.required-text').should('not.be.visible');
         });
@@ -78,7 +79,7 @@ describe('Youth Pass Address Section Required Fields', () => {
         const applicantStreetAddress = `${faker.datatype.number()} ${faker.address.streetName()} ${faker.address.streetSuffix()}`;
 
         cy.get('#element101').type(applicantStreetAddress).blur();
-        cy.get('#form-section-6 > .form-section-buttons > .form-submit-button').click();
+        cy.get('#form-section-7 > .form-section-buttons > .form-submit-button').click();
         cy.get('#form-element-wrapper_101').within(() => {
             cy.get('div.required-text').should('not.be.visible');
         });
@@ -97,7 +98,7 @@ describe('Youth Pass Address Section Required Fields', () => {
         const applicantCity = faker.address.city();
 
         cy.get('#element103').type(applicantCity).blur();
-        cy.get('#form-section-6 > .form-section-buttons > .form-submit-button').click();
+        cy.get('#form-section-7 > .form-section-buttons > .form-submit-button').click();
         cy.get('#form-element-wrapper_103').within(() => {
             cy.get('div.required-text').should('not.be.visible');
         });
@@ -113,7 +114,7 @@ describe('Youth Pass Address Section Required Fields', () => {
         const applicantZipCode = '02114';
 
         cy.get('#element154').type(applicantZipCode).blur();
-        cy.get('#form-section-6 > .form-section-buttons > .form-submit-button').click();
+        cy.get('#form-section-7 > .form-section-buttons > .form-submit-button').click();
         cy.get('#form-element-wrapper_154').within(() => {
             cy.get('div.required-text').should('not.be.visible');
         });
@@ -123,8 +124,8 @@ describe('Youth Pass Address Section Required Fields', () => {
     });
     
     it('does not fill any mailing address fields and sees required field errors', () => {              
-        cy.get('#element122_Option_2').click().blur();
-        cy.get('#form-section-6 > .form-section-buttons > .form-submit-button').click();
+        cy.get('#element122_No').click().blur();
+        cy.get('#form-section-7 > .form-section-buttons > .form-submit-button').click();
         cy.get('#form-element-wrapper_117').within(() => {
             cy.get('div.required-text').should('be.visible');
         });  
@@ -140,7 +141,7 @@ describe('Youth Pass Address Section Required Fields', () => {
         const applicantMailingAddress = `${faker.datatype.number()} ${faker.address.streetName()} ${faker.address.streetSuffix()}`;
 
         cy.get('#element117').type(applicantMailingAddress).blur();
-        cy.get('#form-section-6 > .form-section-buttons > .form-submit-button').click();
+        cy.get('#form-section-7 > .form-section-buttons > .form-submit-button').click();
         cy.get('#form-element-wrapper_117').within(() => {
             cy.get('div.required-text').should('not.be.visible');
         });  
@@ -156,7 +157,7 @@ describe('Youth Pass Address Section Required Fields', () => {
         const applicantMailingCity = faker.address.city();
 
         cy.get('#element119').type(applicantMailingCity).blur();
-        cy.get('#form-section-6 > .form-section-buttons > .form-submit-button').click();
+        cy.get('#form-section-7 > .form-section-buttons > .form-submit-button').click();
         cy.get('#form-element-wrapper_119').within(() => {
             cy.get('div.required-text').should('not.be.visible');
         });  

--- a/cypress/automated-tests/youth-pass/eligibility-checker-blockers.spec.js
+++ b/cypress/automated-tests/youth-pass/eligibility-checker-blockers.spec.js
@@ -6,6 +6,7 @@ describe('Eligibility Checker Blockers', () => {
     const eligibleZipCode = '02114'; 
 
     it('enters a random ineligible zip code', () => {
+        // all eligible zip codes currently start with "0", so starting any random 5-digit number with "1" should guarantee an ineligible zip without hardcoding 
         const ineligibleZipCode = Math.floor(Math.random() * 90000) + 10000;
 
         cy.visit(youthPassUrl);

--- a/cypress/automated-tests/youth-pass/eligibility-checker-blockers.spec.js
+++ b/cypress/automated-tests/youth-pass/eligibility-checker-blockers.spec.js
@@ -5,9 +5,8 @@ describe('Eligibility Checker Blockers', () => {
     const youthPassUrl = Cypress.env('youth_pass_url');
     const eligibleZipCode = '02114'; 
 
-    it('enters an ineligible zip code', () => {
+    it('enters a random ineligible zip code', () => {
         const ineligibleZipCode = Math.floor(Math.random() * 90000) + 10000;
-        cy.log(ineligibleZipCode);
 
         cy.visit(youthPassUrl);
         cy.get('#form-section-0 > .form-section-buttons > .form-section-next').click();

--- a/cypress/automated-tests/youth-pass/eligibility-checker-blockers.spec.js
+++ b/cypress/automated-tests/youth-pass/eligibility-checker-blockers.spec.js
@@ -6,15 +6,17 @@ describe('Eligibility Checker Blockers', () => {
     const eligibleZipCode = '02114'; 
 
     it('enters an ineligible zip code', () => {
-        const ineligibleZipCode = '01545';
+        const ineligibleZipCode = Math.floor(Math.random() * 90000) + 10000;
+        cy.log(ineligibleZipCode);
 
         cy.visit(youthPassUrl);
         cy.get('#form-section-0 > .form-section-buttons > .form-section-next').click();
+        cy.get('#form-section-1 > .form-section-buttons > .form-section-next').click();
         cy.get('#form-element-wrapper_182').should('not.be.visible');
 
         cy.get('#element105').type(ineligibleZipCode).blur();
         cy.get('#form-element-wrapper_182').should('be.visible');
-        cy.get('#form-section-1 > .form-section-buttons > .form-section-next').should('not.be.visible');
+        cy.get('#form-section-2 > .form-section-buttons > .form-section-next').should('not.be.visible');
     });
     
     it('enters an age below 12', () => {
@@ -22,12 +24,13 @@ describe('Eligibility Checker Blockers', () => {
             
         cy.reload();
         cy.get('#form-section-0 > .form-section-buttons > .form-section-next').click();
+        cy.get('#form-section-1 > .form-section-buttons > .form-section-next').click();
         cy.get('#element105').type(eligibleZipCode).blur();
         cy.get('#form-element-wrapper_171').should('not.be.visible');
 
         cy.get('#element15').type(ineligibleBirthdateTooYoung).blur();
         cy.get('#form-element-wrapper_171').should('be.visible');
-        cy.get('#form-section-1 > .form-section-buttons > .form-section-next').should('not.be.visible');
+        cy.get('#form-section-2 > .form-section-buttons > .form-section-next').should('not.be.visible');
 });
 
     it('enters an age above 25', () => {
@@ -35,12 +38,13 @@ describe('Eligibility Checker Blockers', () => {
         
         cy.reload();
         cy.get('#form-section-0 > .form-section-buttons > .form-section-next').click();
+        cy.get('#form-section-1 > .form-section-buttons > .form-section-next').click();
         cy.get('#element105').type(eligibleZipCode).blur();
         cy.get('#form-element-wrapper_172').should('not.be.visible');
 
         cy.get('#element15').type(ineligibleBirthdateTooOld).blur();
         cy.get('#form-element-wrapper_172').should('be.visible');
-        cy.get('#form-section-1 > .form-section-buttons > .form-section-next').should('not.be.visible');
+        cy.get('#form-section-2 > .form-section-buttons > .form-section-next').should('not.be.visible');
     });
     
     it('is able or may be able to get a student pass through school', () => {
@@ -48,19 +52,20 @@ describe('Eligibility Checker Blockers', () => {
         
         cy.reload();
         cy.get('#form-section-0 > .form-section-buttons > .form-section-next').click();
+        cy.get('#form-section-1 > .form-section-buttons > .form-section-next').click();
         cy.get('#element105').type(eligibleZipCode).blur();
         cy.get('#element15').type(eligibleBirthdate12to17).blur();
-        cy.get('#form-section-1 > .form-section-buttons > .form-section-next').click();
+        cy.get('#form-section-2 > .form-section-buttons > .form-section-next').click();
         cy.get('#form-element-wrapper_161').should('not.be.visible');
         cy.get('#form-element-wrapper_162').should('not.be.visible');
         
-        cy.get('#element159_Option_1').click().blur();
-        cy.get('#element160_Option_1').click().blur();
+        cy.get('#element159_Yes').click().blur();
+        cy.get('#element160_Yes').click().blur();
         cy.get('#form-element-wrapper_161').should('be.visible');
 
-        cy.get('#element160_Option_3').click().blur();
+        cy.get('#element160_Unsure').click().blur();
         cy.get('#form-element-wrapper_162').should('be.visible');
-        cy.get('#form-section-2 > .form-section-buttons > .form-section-next').should('not.be.visible');
+        cy.get('#form-section-3 > .form-section-buttons > .form-section-next').should('not.be.visible');
     });
 
     it('does not participate in a partner program', () => {
@@ -68,14 +73,15 @@ describe('Eligibility Checker Blockers', () => {
 
         cy.reload();
         cy.get('#form-section-0 > .form-section-buttons > .form-section-next').click();
+        cy.get('#form-section-1 > .form-section-buttons > .form-section-next').click();
         cy.get('#element105').type(eligibleZipCode).blur();
         cy.get('#element15').type(eligibleBirthdate18to25).blur();
-        cy.get('#form-section-1 > .form-section-buttons > .form-section-next').click();
+        cy.get('#form-section-2 > .form-section-buttons > .form-section-next').click();
         cy.get('#form-element-wrapper_165').should('not.be.visible');
         
-        cy.get('#element164_Option_2').click().blur();
+        cy.get('#element164_No').click().blur();
         cy.get('#form-element-wrapper_165').should('be.visible');
-        cy.get('#form-section-3 > .form-section-buttons > .form-section-next').should('not.be.visible');
+        cy.get('#form-section-4 > .form-section-buttons > .form-section-next').should('not.be.visible');
     });
 });
 

--- a/cypress/automated-tests/youth-pass/file-type-upload.spec.js
+++ b/cypress/automated-tests/youth-pass/file-type-upload.spec.js
@@ -17,27 +17,28 @@ describe('Youth Pass File Uploads', () => {
         
         cy.visit(youthPassUrl);
         cy.get('#form-section-0 > .form-section-buttons > .form-section-next').click();
+        cy.get('#form-section-1 > .form-section-buttons > .form-section-next').click();
         cy.get('#element105').type(applicantZipCode).blur();
         cy.get('#element15').type(applicantBirthdate).blur();
-        cy.get('#form-section-1 > .form-section-buttons > .form-section-next').click();
+        cy.get('#form-section-2 > .form-section-buttons > .form-section-next').click();
         
-        cy.get('#element164_Option_1').click().blur();
-        cy.get('#form-section-3 > .form-section-buttons > .form-section-next').click();
+        cy.get('#element164_Yes').click().blur();
+        cy.get('#form-section-4 > .form-section-buttons > .form-section-next').click();
         
-        cy.get('#element116_Option_1').click().blur();
+        cy.get('#element116_Apply').click().blur();
         cy.get('#element11').type(applicantFirstName).blur();
         cy.get('#element13').type(applicantLastName).blur();
-        cy.get('#form-section-4 > .form-section-buttons > .form-section-next').click();
+        cy.get('#form-section-5 > .form-section-buttons > .form-section-next').click();
         
         cy.get('#element17').type(applicantPhoneNumber).blur();
         cy.get('#element18').type(applicantEmailAddress).blur();
-        cy.get('#form-section-5 > .form-section-buttons > .form-section-next').click();
+        cy.get('#form-section-6 > .form-section-buttons > .form-section-next').click();
                 
         cy.get('#element101').type(applicantStreetAddress).blur();
         cy.get('#element103').type(applicantCity).blur();
         cy.get('#element154').type(applicantZipCode).blur();
-        cy.get('#element122_Option_1').click().blur();
-        cy.get('#form-section-6 > .form-section-buttons > .form-section-next').click();
+        cy.get('#element122_Yes').click().blur();
+        cy.get('#form-section-7 > .form-section-buttons > .form-section-next').click();
     });
     
     it('fails to upload a DOCX file to proof of age', () => {
@@ -71,7 +72,7 @@ describe('Youth Pass File Uploads', () => {
     it('successfully uploads a JPEG file to proof of age', () => {
         cy.get('#element133').attachFile('youth-pass-test-image.jpeg')
         cy.get('.k-text-success').should('exist');
-        cy.get('#form-section-7 > .form-section-buttons > .form-section-next').click();
+        cy.get('#form-section-8 > .form-section-buttons > .form-section-next').click();
     });
       
     it('fails to upload a DOCX file to proof of address', () => {
@@ -105,7 +106,7 @@ describe('Youth Pass File Uploads', () => {
     it('successfully uploads a PDF file to proof of address', () => {
         cy.get('#element39').attachFile('youth-pass-test-image.pdf')
         cy.get('.k-text-success').should('exist');
-        cy.get('#form-section-8 > .form-section-buttons > .form-section-next').click();
+        cy.get('#form-section-9 > .form-section-buttons > .form-section-next').click();
     });
 
     it('fails to upload an RTF file to proof of program enrollment', () => {

--- a/cypress/automated-tests/youth-pass/personal-contact-sections-required-fields.spec.js
+++ b/cypress/automated-tests/youth-pass/personal-contact-sections-required-fields.spec.js
@@ -10,16 +10,17 @@ describe('Youth Pass Personal and Contact Info Section Required Fields', () => {
         
         cy.visit(youthPassUrl);
         cy.get('#form-section-0 > .form-section-buttons > .form-section-next').click();
+        cy.get('#form-section-1 > .form-section-buttons > .form-section-next').click();
         cy.get('#element105').type(applicantZipCode).blur();
         cy.get('#element15').type(applicantBirthdate).blur();
-        cy.get('#form-section-1 > .form-section-buttons > .form-section-next').click();
+        cy.get('#form-section-2 > .form-section-buttons > .form-section-next').click();
         
-        cy.get('#element164_Option_1').click().blur();
-        cy.get('#form-section-3 > .form-section-buttons > .form-section-next').click();
+        cy.get('#element164_Yes').click().blur();
+        cy.get('#form-section-4 > .form-section-buttons > .form-section-next').click();
     });
     
     it('does not fill any personal info fields and sees required field errors', () => {              
-        cy.get('#form-section-4 > .form-section-buttons > .form-submit-button').click();
+        cy.get('#form-section-5 > .form-section-buttons > .form-submit-button').click();
         cy.get('#form-element-wrapper_116').within(() => {
             cy.get('div.required-text').should('be.visible');
         });
@@ -32,8 +33,8 @@ describe('Youth Pass Personal and Contact Info Section Required Fields', () => {
     });
     
     it('only fills application options radio and sees required field errors', () => {              
-        cy.get('#element116_Option_1').click().blur();
-        cy.get('#form-section-4 > .form-section-buttons > .form-submit-button').click();
+        cy.get('#element116_Apply').click().blur();
+        cy.get('#form-section-5 > .form-section-buttons > .form-submit-button').click();
         cy.get('#form-element-wrapper_116').within(() => {
             cy.get('div.required-text').should('not.be.visible');
         });
@@ -49,7 +50,7 @@ describe('Youth Pass Personal and Contact Info Section Required Fields', () => {
         const applicantFirstName = faker.name.firstName();
 
         cy.get('#element11').type(applicantFirstName).blur();
-        cy.get('#form-section-4 > .form-section-buttons > .form-submit-button').click();
+        cy.get('#form-section-5 > .form-section-buttons > .form-submit-button').click();
         cy.get('#form-element-wrapper_11').within(() => {
             cy.get('div.required-text').should('not.be.visible');
         });
@@ -63,11 +64,11 @@ describe('Youth Pass Personal and Contact Info Section Required Fields', () => {
 
         cy.get('#element13').type(applicantLastName).blur();
         cy.get('div.required-text').should('not.be.visible');
-        cy.get('#form-section-4 > .form-section-buttons > .form-section-next').click();
+        cy.get('#form-section-5 > .form-section-buttons > .form-section-next').click();
     });
     
     it('does not fill any contact info fields and sees required field errors', () => {              
-        cy.get('#form-section-5 > .form-section-buttons > .form-submit-button').click();
+        cy.get('#form-section-6 > .form-section-buttons > .form-submit-button').click();
         cy.get('#form-element-wrapper_17').within(() => {
             cy.get('div.required-text').should('be.visible');
         });
@@ -80,7 +81,7 @@ describe('Youth Pass Personal and Contact Info Section Required Fields', () => {
         const applicantPhoneNumber = faker.phone.phoneNumberFormat();
 
         cy.get('#element17').type(applicantPhoneNumber).blur();
-        cy.get('#form-section-5 > .form-section-buttons > .form-submit-button').click();
+        cy.get('#form-section-6 > .form-section-buttons > .form-submit-button').click();
         cy.get('#form-element-wrapper_17').within(() => {
             cy.get('div.required-text').should('not.be.visible');
         });

--- a/cypress/automated-tests/youth-pass/successful-youth-pass-submission.spec.js
+++ b/cypress/automated-tests/youth-pass/successful-youth-pass-submission.spec.js
@@ -11,22 +11,23 @@ describe('Youth Pass Successful Submission', () => {
 
         cy.visit(youthPassUrl);
         cy.get('#form-section-0 > .form-section-buttons > .form-section-next').click();
+        cy.get('#form-section-1 > .form-section-buttons > .form-section-next').click();
         cy.get('#element105').type(applicantZipCode).blur();
         cy.get('#element15').type(applicantBirthdate).blur();
-        cy.get('#form-section-1 > .form-section-buttons > .form-section-next').click();
+        cy.get('#form-section-2 > .form-section-buttons > .form-section-next').click();
         
-        cy.get('#element164_Option_1').click().blur();
-        cy.get('#form-section-3 > .form-section-buttons > .form-section-next').click();
+        cy.get('#element164_Yes').click().blur();
+        cy.get('#form-section-4 > .form-section-buttons > .form-section-next').click();
     });
 
     it('completes the personal information section', () => {
         const applicantFirstName = faker.name.firstName();
         const applicantLastName = faker.name.lastName();
 
-        cy.get('#element116_Option_1').click().blur();
+        cy.get('#element116_Apply').click().blur();
         cy.get('#element11').type(applicantFirstName).blur();
         cy.get('#element13').type(applicantLastName).blur();
-        cy.get('#form-section-4 > .form-section-buttons > .form-section-next').click();
+        cy.get('#form-section-5 > .form-section-buttons > .form-section-next').click();
     });
 
     it('completes the contact information section', () => {
@@ -35,47 +36,47 @@ describe('Youth Pass Successful Submission', () => {
         
         cy.get('#element17').type(applicantPhoneNumber).blur();
         cy.get('#element18').type(applicantEmailAddress).blur();
-        cy.get('#form-section-5 > .form-section-buttons > .form-section-next').click();
+        cy.get('#form-section-6 > .form-section-buttons > .form-section-next').click();
     });
 
     it('completes the address section', () => {
         const applicantStreetAddress = `${faker.datatype.number()} ${faker.address.streetName()} ${faker.address.streetSuffix()}`;
         const applicantCity = faker.address.city();
 
-        cy.get('#element242_Option_2').click().blur();
+        cy.get('#element242_Person').click().blur();
         cy.get('#element101').type(applicantStreetAddress).blur();
         cy.get('#element103').type(applicantCity).blur();
         cy.get('#element154').type(applicantZipCode).blur();
-        cy.get('#form-section-6 > .form-section-buttons > .form-section-next').click();
+        cy.get('#form-section-7 > .form-section-buttons > .form-section-next').click();
     });
 
     it('completes the proof of age section', () => {
         cy.get('#element114_Option_1').click().blur();
         cy.get('#element133').attachFile('youth-pass-test-image.png')
         cy.get('.k-text-success').should('exist');
-        cy.get('#form-section-7 > .form-section-buttons > .form-section-next').click();
+        cy.get('#form-section-8 > .form-section-buttons > .form-section-next').click();
     });
 
     it('completes the proof of address section', () => {
         cy.get('#element135_Option_1').click().blur();
         cy.get('#element39').attachFile('youth-pass-test-image.png')
         cy.get('.k-text-success').should('exist');
-        cy.get('#form-section-8 > .form-section-buttons > .form-section-next').click();
+        cy.get('#form-section-9 > .form-section-buttons > .form-section-next').click();
     });
 
     it('completes the proof of program eligiblity section', () => {
         cy.get('#element42').select('Child Care (DTA, EEC)', { force: true });
         cy.get('#element136').attachFile('youth-pass-test-image.png')
         cy.get('.k-text-success').should('exist');
-        cy.get('#form-section-9 > .form-section-buttons > .form-section-next').click();
+        cy.get('#form-section-10 > .form-section-buttons > .form-section-next').click();
         
         cy.get('#element52_Option_2').click().blur();
-        cy.get('#form-section-10 > .form-section-buttons > .form-section-next').click();
+        cy.get('#form-section-11 > .form-section-buttons > .form-section-next').click();
     });
 
     it('agrees to terms and conditions and submits application', () => {
         cy.get('#element50').click().blur();
-        cy.get('#form-section-11 > .form-section-buttons > .form-submit-button').click();
+        cy.get('#form-section-12 > .form-section-buttons > .form-submit-button').click();
 
         cy.get('#thank-you-text', { timeout: 15000 }).should('contain', 'Application Submitted')
         cy.get('#thank-you-text', { timeout: 15000 }).should('contain', 'ebalkam@mbta.com')


### PR DESCRIPTION
The Reduced Fares team is releasing Language Translations for the Youth Pass application. 
This PR updates Youth Pass automation scripts with necessary changes to accommodate language translations:

- Updated tab numbers for `Next` button element selectors
- Updated IDs for any radio option elements (changes made to strengthen Youth Pass application logic in SimpliGov)

The updated scripts passed 10 local runs within Cypress and a [PreProd GitHub action manual run](https://github.com/mbta/reduced_fares/runs/4704972809?check_suite_focus=true). 

Asana ticket: https://app.asana.com/0/1170867711449497/1201591940415700/f