### PR TITLE
Fix: Transform environment script syntax

### DIFF
--- a/transform-environment
+++ b/transform-environment
@@ -22,7 +22,7 @@ def main(args):
     input_file.close()
 
     preprod_input_string = f'\"preprod\\'
-    environment_output_string = f'\{args["--environment"]}\\'
+    environment_output_string = f'\"{args["--environment"]}\\'
 
     transformed_data = input_data.replace(preprod_input_string, environment_output_string)
 


### PR DESCRIPTION
While double-checking files today in preparation for a deployment, I noticed a syntax difference between environment names in the input and output files. This PR adds a `"` to the output file, so the environment name matches exactly to the input file. 

No Asana ticket. 