### PR TITLE
Fix: Standardize email error color via CSS

### DIFF
--- a/stylesheets/Youth-Pass-Basic.css
+++ b/stylesheets/Youth-Pass-Basic.css
@@ -382,7 +382,8 @@ h5 {
 
 /* Required text and regex error color */
 .required-text,
-.regexErrorLabel {
+.regexErrorLabel,
+.requiredLabelEmail {
     color: #B3000F!important;
     font-style: normal;
 }


### PR DESCRIPTION
The error message on a partially filled email field within the Youth Pass application was not showing as standard ZeroHeight color. This PR updates the CSS file to capture this partially filled field error state. 

Asana ticket: https://app.asana.com/0/1170867711449497/1201613591661873/f