### PR TITLE
feat: Add a generic email template to use in SimpliGov

### DIFF
--- a/assets/email-template.html
+++ b/assets/email-template.html
@@ -1,0 +1,388 @@
+<!doctype html>
+<html>
+
+<head>
+	<meta charset="UTF-8">
+	<meta name="viewport" content="width=device-width, initial-scale=1">
+
+	<title>[SUBJECT]</title>
+
+	<style type="text/css">
+		p {
+			margin: 10px 0;
+			padding: 0;
+		}
+
+		table {
+			border-collapse: collapse;
+      /* Outlook-specific styles to remove extra spacing on the left and right side of a table element */
+			mso-table-lspace: 0pt;
+			mso-table-rspace: 0pt;
+		}
+
+		h1,
+		h2,
+		h3,
+		h4,
+		h5,
+		h6 {
+			display: block;
+			margin: 0;
+			padding: 0;
+		}
+
+		img,
+		a img {
+			border: 0;
+			height: auto;
+			outline: none;
+			text-decoration: none;
+		}
+
+		body,
+		#bodyTable,
+		#bodyCell {
+			height: 100%;
+			margin: 0;
+			padding: 0;
+			width: 100%;
+		}
+
+		img {
+			-ms-interpolation-mode: bicubic;
+		}
+
+		p,
+		a,
+		li,
+		td,
+		blockquote {
+			/* Outlook-specific */
+			mso-line-height-rule: exactly;
+		}
+
+		a[href^=tel],
+		a[href^=sms] {
+			color: inherit;
+			cursor: default;
+			text-decoration: none;
+		}
+
+		p,
+		a,
+		li,
+		td,
+		body,
+		table,
+		blockquote {
+			-ms-text-size-adjust: 100%;
+			-webkit-text-size-adjust: 100%;
+		}
+
+		#bodyCell {
+			padding: 10px;
+		}
+
+		.templateContainer {
+      border: 0;
+			max-width: 600px !important;
+		}
+
+		.mcnImage {
+			vertical-align: bottom;
+		}
+
+		.mcnTextContent {
+			word-break: break-word;
+		}
+
+		.mcnTextContent img {
+			height: auto !important;
+		}
+
+		body,
+		#bodyTable {
+			background-color: #ffffff;
+		}
+
+		#bodyCell {
+			border-top: 0;
+		}
+
+		h1 {
+			color: #202020;
+			font-family: Helvetica;
+			font-size: 26px;
+			font-style: normal;
+			font-weight: bold;
+			line-height: 125%;
+			letter-spacing: normal;
+			text-align: left;
+		}
+
+		h2 {
+			color: #202020;
+			font-family: Helvetica;
+			font-size: 22px;
+			font-style: normal;
+			font-weight: bold;
+			line-height: 125%;
+			letter-spacing: normal;
+			text-align: left;
+		}
+
+		h3 {
+			color: #202020;
+			font-family: Helvetica;
+			font-size: 20px;
+			font-style: normal;
+			font-weight: bold;
+			line-height: 125%;
+			letter-spacing: normal;
+			text-align: left;
+		}
+
+		h4 {
+			color: #202020;
+			font-family: Helvetica;
+			font-size: 18px;
+			font-style: normal;
+			font-weight: bold;
+			line-height: 125%;
+			letter-spacing: normal;
+			text-align: left;
+		}
+
+		#templateHeader {
+			background-color: #FFFFFF;
+			background-image: none;
+			background-repeat: no-repeat;
+			background-position: center;
+			background-size: cover;
+			border-top: 0;
+			border-bottom: 0;
+			padding-top: 9px;
+			padding-bottom: 0;
+		}
+
+		#templateHeader .mcnTextContent,
+		#templateHeader .mcnTextContent p {
+			color: #202020;
+			font-family: Helvetica;
+			font-size: 16px;
+			line-height: 150%;
+			text-align: left;
+		}
+
+    #templateHeader .mcnTextContent a,
+		#templateHeader .mcnTextContent p a {
+			color: #007C89;
+			font-weight: normal;
+			text-decoration: underline;
+		}
+
+		#templateBody {
+			background-color: #ffffff;
+			background-image: none;
+			background-repeat: no-repeat;
+			background-position: center;
+			background-size: cover;
+			border-top: 0;
+			border-bottom: 2px solid #EAEAEA;
+			padding-top: 0;
+			padding-bottom: 9px;
+		}
+
+    #templateBody .mcnTextContent,
+		#templateBody .mcnTextContent p {
+			color: #202020;
+			font-family: Helvetica;
+			font-size: 16px;
+			line-height: 150%;
+			text-align: left;
+		}
+
+		#templateBody .mcnTextContent a,
+		#templateBody .mcnTextContent p a {
+			color: #165c96;
+			font-weight: normal;
+			text-decoration: underline;
+		}
+
+		@media only screen and (min-width:768px) {
+			.templateContainer {
+				width: 600px !important;
+			}
+		}
+
+		@media only screen and (max-width: 480px) {
+			body,
+			table,
+			td,
+			p,
+			a,
+			li,
+			blockquote {
+				-webkit-text-size-adjust: none !important;
+			}
+
+      body {
+				width: 100% !important;
+				min-width: 100% !important;
+			}
+
+      h1 {
+				font-size: 22px !important;
+				line-height: 125% !important;
+			}
+
+      h2 {
+				font-size: 20px !important;
+				line-height: 125% !important;
+			}
+
+      h3 {
+				font-size: 18px !important;
+				line-height: 125% !important;
+			}
+
+      h4 {
+				font-size: 16px !important;
+				line-height: 150% !important;
+			}
+
+      .mcnImage {
+				width: 100% !important;
+			}
+
+
+      #templateHeader .mcnTextContent,
+			#templateHeader .mcnTextContent p {
+				font-size: 16px !important;
+				line-height: 150% !important;
+			}
+
+      #templateBody .mcnTextContent,
+			#templateBody .mcnTextContent p {
+				font-size: 16px !important;
+				line-height: 150% !important;
+			}
+
+      .mcnTextContentContainer  {
+				max-width: 100% !important;
+				width: 100% !important;
+			}
+
+      .mcnTextContent {
+				padding-right: 18px !important;
+				padding-left: 18px !important;
+			}
+		}
+	</style>
+</head>
+
+<body>
+	<center>
+		<table align="center" border="0" cellpadding="0" cellspacing="0" height="100%" width="100%" id="bodyTable">
+			<tr>
+				<td align="center" valign="top" id="bodyCell">
+					<!-- BEGIN TEMPLATE // -->
+					<!--[if (gte mso 9)|(IE)]>
+                        <table align="center" border="0" cellspacing="0" cellpadding="0" width="600" style="width:600px;">
+                        <tr>
+                        <td align="center" valign="top" width="600" style="width:600px;">
+					<![endif]-->
+					<table border="0" cellpadding="0" cellspacing="0" width="100%" class="templateContainer">
+						<tr>
+							<td valign="top" id="templateHeader">
+								<table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnBoxedTextBlock"
+									style="min-width:100%;">
+								</table>
+								<table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnImageBlock"
+									style="min-width:100%;">
+									<tbody class="mcnImageBlockOuter">
+										<tr>
+											<td valign="top" style="padding:9px" class="mcnImageBlockInner">
+												<table align="left" width="100%" border="0" cellpadding="0"
+													cellspacing="0" class="mcnImageContentContainer"
+													style="min-width:100%;">
+													<tbody>
+														<tr>
+															<td class="mcnImageContent" valign="top"
+																style="padding-right: 9px; padding-left: 9px; padding-top: 0; padding-bottom: 0; text-align:center;">
+																<img align="center"
+																	alt="Logo of the Massachusetts Bay Transportation Authority"
+																	src="https://gallery.mailchimp.com/d69747d5fc9f30fa7321ea932/images/bcf766a9-2f0e-4ac7-88ff-d303e92c9056.png"
+																	width="564"
+																	style="max-width:979px; padding-bottom: 0; display: inline !important; vertical-align: bottom;"
+																	class="mcnImage">
+															</td>
+														</tr>
+													</tbody>
+												</table>
+											</td>
+										</tr>
+									</tbody>
+								</table>
+							</td>
+						</tr>
+						<tr>
+							<td valign="top" id="templateBody">
+								<table border="0" cellpadding="0" cellspacing="0" width="100%" class="mcnTextBlock"
+									style="min-width:100%;">
+									<tbody class="mcnTextBlockOuter">
+										<tr>
+											<td valign="top" class="mcnTextBlockInner" style="padding-top:9px;">
+												<!--[if mso]>
+													<table align="left" border="0" cellspacing="0" cellpadding="0" width="100%" style="width:100%;">
+													<tr>
+												<![endif]-->
+
+												<!--[if mso]>
+													<td valign="top" width="600" style="width:600px;">
+												<![endif]-->
+												<table align="left" border="0" cellpadding="0" cellspacing="0"
+													style="max-width:100%; min-width:100%;" width="100%"
+													class="mcnTextContentContainer">
+													<tbody>
+														<tr>
+															<td valign="top" class="mcnTextContent"
+																style="padding: 0px 18px 9px; font-family: 'Helvetica Neue', Helvetica, Arial, Verdana, sans-serif;">
+
+																<p dir="ltr"
+																	style="font-family: 'Helvetica Neue', Helvetica, Arial, Verdana, sans-serif;">
+																	<span style="font-size:18px">
+																		<span style="font-family:helvetica neue,helvetica,arial,verdana,sans-serif">
+																			<br>
+
+																			[Email text placeholder]
+
+																		</span>
+																	</span>
+																</p>
+															</td>
+														</tr>
+													</tbody>
+												</table>
+											<!--[if mso]>
+												</td>
+											<![endif]-->
+
+											<!--[if mso]>
+												</tr>
+												</table>
+											<![endif]-->
+											</td>
+										</tr>
+									</tbody>
+								</table>
+							</td>
+						</tr>
+					<!-- // END TEMPLATE -->
+				</td>
+			</tr>
+		</table>
+	</center>
+</body>
+
+</html>


### PR DESCRIPTION
Copied from the [sso-static project](https://github.com/mbta/sso-static/blob/main/email.html)
and cleaned up a bit.

Specific content can replace the "[SUBJECT]" and "[Email text placeholder]" placeholders.