### PR TITLE
chore(deps-dev): bump cypress from 9.5.1 to 9.5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -525,9 +525,9 @@
       }
     },
     "node_modules/cypress": {
-      "version": "9.5.1",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-9.5.1.tgz",
-      "integrity": "sha512-H7lUWB3Svr44gz1rNnj941xmdsCljXoJa2cDneAltjI9leKLMQLm30x6jLlpQ730tiVtIbW5HdUmBzPzwzfUQg==",
+      "version": "9.5.2",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-9.5.2.tgz",
+      "integrity": "sha512-gYiQYvJozMzDOriUV1rCt6CeRM/pRK4nhwGJj3nJQyX2BoUdTCVwp30xDMKc771HiNVhBtgj5o5/iBdVDVXQUg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
@@ -2240,9 +2240,9 @@
       }
     },
     "cypress": {
-      "version": "9.5.1",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-9.5.1.tgz",
-      "integrity": "sha512-H7lUWB3Svr44gz1rNnj941xmdsCljXoJa2cDneAltjI9leKLMQLm30x6jLlpQ730tiVtIbW5HdUmBzPzwzfUQg==",
+      "version": "9.5.2",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-9.5.2.tgz",
+      "integrity": "sha512-gYiQYvJozMzDOriUV1rCt6CeRM/pRK4nhwGJj3nJQyX2BoUdTCVwp30xDMKc771HiNVhBtgj5o5/iBdVDVXQUg==",
       "dev": true,
       "requires": {
         "@cypress/request": "^2.88.10",


### PR DESCRIPTION
[Release](https://github.com/cypress-io/cypress/releases/tag/v9.5.2)