### PR TITLE
fix: Fix npm root directory in dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: npm
-    directory: "/assets"
+    directory: "/"
     schedule:
       interval: daily
       time: "09:00"


### PR DESCRIPTION
I suspect I copied this from another project where the `package.json` file was located in the `assets` directory.