### PR TITLE
Fix: S3 URL test dashboard flakiness

### DIFF
--- a/cypress/automated-tests/youth-pass/document-viewer-s3-urls.spec.js
+++ b/cypress/automated-tests/youth-pass/document-viewer-s3-urls.spec.js
@@ -21,6 +21,7 @@ describe('Youth Pass Document Viewer S3 URL Visibility', () => {
         // find and approve application
         cy.get('[aria-rowindex="1"]').should('contain', applicantFirstName)
         cy.get(applicationActionButton).click();
+        cy.wait(2000);
         cy.get(':nth-child(2) > .dashboard-actions').should('be.visible').click();
         cy.get('#element189_Option_1').click();
         cy.get('.form-submit-button').click();
@@ -28,6 +29,9 @@ describe('Youth Pass Document Viewer S3 URL Visibility', () => {
         
         // view audit trail and assert
         cy.visit(youthPassDashboard);
+        cy.wait(3000);
+        cy.get('.dashboard > .records').click();
+        cy.get('[aria-rowindex="1"]').should('contain', 'Approved (pick up later)')
         cy.get('.fa-list').click();
         cy.get(applicationActionButton).click();
         cy.get(':nth-child(3) > .dashboard-actions').should('be.visible').click();


### PR DESCRIPTION
The RF team has noticed flakiness in the S3 URL script. Debugging showed that the SimpliGov dashboard is sometimes not updating following user actions. 

This PR adds `wait` and `click` steps as well as an assertion to basically force-update the SimpliGov dashboard. This is not ideal for automation scripts, but the source code/behavior is out of our control and this behavior is preventing us from testing the intended outcome (Document Viewer URL visibility). 