### PR TITLE
Fix: S3 URL Script updates

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -2,6 +2,7 @@
   "integrationFolder": "cypress/automated-tests",
   "defaultCommandTimeout": 10000,
   "video": false,
+  "chromeWebSecurity": false,
   "env": {
     "youth_pass_url": "https://mbta.preprod.simpligov.com/preprod/portal/ShowWorkFlow/AnonymousEmbed/86cadfa6-e8ea-46f1-b6e8-62498f066962",
     "youth_pass_dashboard_url": "https://mbta.preprod.simpligov.com/preprod/portal/Dashboard",

--- a/cypress/automated-tests/youth-pass/document-viewer-s3-urls.spec.js
+++ b/cypress/automated-tests/youth-pass/document-viewer-s3-urls.spec.js
@@ -12,7 +12,6 @@ describe('Youth Pass Document Viewer S3 URL Visibility', () => {
 
     it('sees three document viewer URLs when logged in as a group admin', () => {
         const youthPassDashboard = Cypress.env('youth_pass_dashboard_url');
-        const applicationActionButton = '#dataGridContainer > .dx-gridbase-container > .dx-datagrid-rowsview > .dx-datagrid-content-fixed > .dx-datagrid-table > tbody > [aria-rowindex="1"] > .actions-column > .select2 > .selection > .select2-selection';
         cy.visit(youthPassDashboard);
         cy.get('#username').type(Cypress.env('malden_test_username'));
         cy.get('#password').type(Cypress.env('malden_test_credentials'));
@@ -20,21 +19,25 @@ describe('Youth Pass Document Viewer S3 URL Visibility', () => {
         
         // find and approve application
         cy.get('[aria-rowindex="1"]').should('contain', applicantFirstName)
-        cy.get(applicationActionButton).click();
+        cy.get('.mytasksboard > .records').click();
+        cy.get('#dx-col-87').click();
         cy.wait(2000);
-        cy.get(':nth-child(2) > .dashboard-actions').should('be.visible').click();
+        cy.get('.dx-datagrid-content-fixed > .dx-datagrid-table > tbody > [aria-rowindex="1"] > .actions-column > .edit-task > span').click();
         cy.get('#element189_Option_1').click();
         cy.get('.form-submit-button').click();
         cy.get('#thank-you-text').should('be.visible');
+        cy.wait(2000);
         
         // view audit trail and assert
-        cy.visit(youthPassDashboard);
-        cy.wait(3000);
+        const applicationActionButton = '#dataGridContainer > .dx-gridbase-container > .dx-datagrid-rowsview > .dx-datagrid-content-fixed > .dx-datagrid-table > tbody > [aria-rowindex="1"] > .actions-column > .select2 > .selection > .select2-selection';
+        cy.get('.exit-workflow-text').click();
+        cy.wait(2000);
+        cy.get('#yesBtn').click();
+        cy.wait(2000);
         cy.get('.dashboard > .records').click();
         cy.get('[aria-rowindex="1"]').should('contain', 'Approved (pick up later)')
-        cy.get('.fa-list').click();
         cy.get(applicationActionButton).click();
-        cy.get(':nth-child(3) > .dashboard-actions').should('be.visible').click();
+        cy.get(':nth-child(4) > .dashboard-actions').should('be.visible').click();
         cy.get(':nth-child(4) > .wrapper-switcher').click();
         cy.get('#AuditLogDiv > :nth-child(4)').should('contain', 'ProofOfAgeS3URL')
         cy.get('#AuditLogDiv > :nth-child(4)').should('contain', 'ProofOfResidencyS3URL')

--- a/cypress/automated-tests/youth-pass/document-viewer-s3-urls.spec.js
+++ b/cypress/automated-tests/youth-pass/document-viewer-s3-urls.spec.js
@@ -27,20 +27,22 @@ describe('Youth Pass Document Viewer S3 URL Visibility', () => {
         cy.get('.form-submit-button').click();
         cy.get('#thank-you-text').should('be.visible');
         cy.wait(2000);
-        
-        // view audit trail and assert
-        const applicationActionButton = '#dataGridContainer > .dx-gridbase-container > .dx-datagrid-rowsview > .dx-datagrid-content-fixed > .dx-datagrid-table > tbody > [aria-rowindex="1"] > .actions-column > .select2 > .selection > .select2-selection';
         cy.get('.exit-workflow-text').click();
         cy.wait(2000);
         cy.get('#yesBtn').click();
         cy.wait(2000);
+        
+        // view audit trail and assert
         cy.get('.dashboard > .records').click();
         cy.get('[aria-rowindex="1"]').should('contain', 'Approved (pick up later)')
-        cy.get(applicationActionButton).click();
-        cy.get(':nth-child(4) > .dashboard-actions').should('be.visible').click();
-        cy.get(':nth-child(4) > .wrapper-switcher').click();
-        cy.get('#AuditLogDiv > :nth-child(4)').should('contain', 'ProofOfAgeS3URL')
-        cy.get('#AuditLogDiv > :nth-child(4)').should('contain', 'ProofOfResidencyS3URL')
-        cy.get('#AuditLogDiv > :nth-child(4)').should('contain', 'ProofOfEligibilityS3URL')
+        cy.get('.mytasksboard > .records').click();
+        cy.get('#dx-col-87').click();
+        cy.wait(2000);
+        cy.get('.dx-datagrid-content-fixed > .dx-datagrid-table > tbody > [aria-rowindex="1"] > .actions-column > .edit-task > span').click();
+        cy.get('#show-info-btn').click();
+        cy.get(':nth-child(5) > .wrapper-switcher').click();
+        cy.get('#AuditLogDiv > :nth-child(5)').should('contain', 'ProofOfAgeS3URL')
+        cy.get('#AuditLogDiv > :nth-child(5)').should('contain', 'ProofOfResidencyS3URL')
+        cy.get('#AuditLogDiv > :nth-child(5)').should('contain', 'ProofOfEligibilityS3URL')
     });
 });


### PR DESCRIPTION
The S3 URL script needs updates due to recent functionality changes. We enabled a "Cancel request" feature for Group Admin users and this changed the order of the Actions menu. 

I saw continued flakiness in this test when running, so I'm avoiding the Actions menu altogether and using "My records" instead. With changes, the script passed 20 consecutive runs (10 in Cypress UI, 10 in command line) as well as a [passing GitHub Actions run](https://github.com/mbta/reduced_fares/runs/5758184431?check_suite_focus=true).

Note this PR does not yet fix the timed-out PreProd run issue. That is an ongoing issue. 