### PR TITLE
Fix: Resolve hanging test runs

### DIFF
--- a/cypress.json
+++ b/cypress.json
@@ -2,6 +2,7 @@
   "integrationFolder": "cypress/automated-tests",
   "defaultCommandTimeout": 10000,
   "video": false,
+  "screenshotOnRunFailure": false,
   "chromeWebSecurity": false,
   "env": {
     "youth_pass_url": "https://mbta.preprod.simpligov.com/preprod/portal/ShowWorkFlow/AnonymousEmbed/86cadfa6-e8ea-46f1-b6e8-62498f066962",

--- a/cypress/automated-tests/youth-pass/successful-youth-pass-submission.spec.js
+++ b/cypress/automated-tests/youth-pass/successful-youth-pass-submission.spec.js
@@ -79,6 +79,6 @@ describe('Youth Pass Successful Submission', () => {
         cy.get('#form-section-12 > .form-section-buttons > .form-submit-button').click();
 
         cy.get('#thank-you-text', { timeout: 15000 }).should('contain', 'Application Submitted')
-        cy.get('#thank-you-text', { timeout: 15000 }).should('contain', 'ebalkam@mbta.com')
+        cy.get('#thank-you-text', { timeout: 15000 }).should('contain', 'krisjohnson@mbta.com')
     });
 });

--- a/cypress/automated-tests/youth-pass/successful-youth-pass-submission.spec.js
+++ b/cypress/automated-tests/youth-pass/successful-youth-pass-submission.spec.js
@@ -79,6 +79,6 @@ describe('Youth Pass Successful Submission', () => {
         cy.get('#form-section-12 > .form-section-buttons > .form-submit-button').click();
 
         cy.get('#thank-you-text', { timeout: 15000 }).should('contain', 'Application Submitted')
-        cy.get('#thank-you-text', { timeout: 15000 }).should('contain', 'krisjohnson@mbta.com')
+        cy.get('#thank-you-text', { timeout: 15000 }).should('contain', 'ebalkam@mbta.com')
     });
 });


### PR DESCRIPTION
We've noticed that some of our Production and PreProd test runs are hanging for 6 hours, then timing out. We observed that this only happens when a script fails and (for some reason) the post-checkout step never kicks off. We theorized that Cypress' default behavior to capture a screenshot might be causing this hang--and we don't use these screenshots for any meaningful purpose.

This PR configures Cypress to no longer capture screenshots of failed tests. Implementing this change on a feature branch caused the a complete test run including several (intentional) failures. 

Asana task: https://app.asana.com/0/1170867711449497/1202049011741428/f 