### PR TITLE
Revert "test: Fix the tests to compensate for hiding the language selection (#89)"

### DIFF
--- a/cypress/automated-tests/senior/birth-date-validation.spec.js
+++ b/cypress/automated-tests/senior/birth-date-validation.spec.js
@@ -15,16 +15,16 @@ describe('senior birth date validation', () => {
       .get('#form-section-0 > .form-section-buttons > .form-section-next')
       .click();
 
+      // Instructions
+    cy
+      .get('#form-section-1 > .form-section-buttons > .form-section-next')
+      .click();
+
     // Application Type
     cy
       .get('[data-field-code="ApplicantStatus"]')
       .contains('Apply for a Senior CharlieCard')
       .click();
-    cy
-      .get('#form-section-1 > .form-section-buttons > .form-section-next')
-      .click();
-  
-    // Instructions
     cy
       .get('#form-section-2 > .form-section-buttons > .form-section-next')
       .click();

--- a/cypress/automated-tests/senior/birth-date-validation.spec.js
+++ b/cypress/automated-tests/senior/birth-date-validation.spec.js
@@ -7,15 +7,13 @@ describe('senior birth date validation', () => {
     cy.visit(seniorUrl);
 
     // Language Selection
-    // Temporarily commented out while the language selection is hidden,
-    // per https://app.asana.com/0/1200240595613188/1201957412884505
-    // cy
-    //   .get('[data-field-code="LanguageSelection"]')
-    //   .contains('English')
-    //   .click();
-    // cy
-    //   .get('#form-section-0 > .form-section-buttons > .form-section-next')
-    //   .click();
+    cy
+      .get('[data-field-code="LanguageSelection"]')
+      .contains('English')
+      .click();
+    cy
+      .get('#form-section-0 > .form-section-buttons > .form-section-next')
+      .click();
 
     // Application Type
     cy
@@ -23,12 +21,12 @@ describe('senior birth date validation', () => {
       .contains('Apply for a Senior CharlieCard')
       .click();
     cy
-      .get('#form-section-0 > .form-section-buttons > .form-section-next')
+      .get('#form-section-1 > .form-section-buttons > .form-section-next')
       .click();
   
     // Instructions
     cy
-      .get('#form-section-1 > .form-section-buttons > .form-section-next')
+      .get('#form-section-2 > .form-section-buttons > .form-section-next')
       .click();
   });
 
@@ -39,7 +37,7 @@ describe('senior birth date validation', () => {
 
     cy.get('.error-alert-item').should('be.visible');
     cy
-      .get('#form-section-2 > .form-section-buttons > .form-section-next')
+      .get('#form-section-3 > .form-section-buttons > .form-section-next')
       .should('not.be.visible');
   });
 });

--- a/cypress/automated-tests/senior/required-fields.spec.js
+++ b/cypress/automated-tests/senior/required-fields.spec.js
@@ -145,7 +145,7 @@ describe('senior required fields', () => {
     cy.get('#element22').clear().blur();
 
     cy
-      .get('#form-section-7 > .form-section-buttons > .form-section-next')
+      .get('#form-section-7 > .form-section-buttons > .form-submit-button')
       .click();
     cy.get('.required-text').should('be.visible');
 
@@ -153,7 +153,7 @@ describe('senior required fields', () => {
     cy.get('#element24').clear().blur();
 
     cy
-      .get('#form-section-7 > .form-section-buttons > .form-section-next')
+      .get('#form-section-7 > .form-section-buttons > .form-submit-button')
       .click();
     cy.get('.required-text').should('be.visible');
 
@@ -161,7 +161,7 @@ describe('senior required fields', () => {
     cy.get('#element26').clear().blur();
 
     cy
-      .get('#form-section-7 > .form-section-buttons > .form-section-next')
+      .get('#form-section-7 > .form-section-buttons > .form-submit-button')
       .click();
     cy.get('.required-text').should('be.visible');
 
@@ -175,7 +175,7 @@ describe('senior required fields', () => {
     cy.get('#element33').type(applicantZipCode).blur();
 
     cy
-      .get('#form-section-7 > .form-section-buttons > .form-section-next')
+      .get('#form-section-7 > .form-section-buttons > .form-submit-button')
       .click();
     cy.get('.required-text').should('be.visible');
 
@@ -183,7 +183,7 @@ describe('senior required fields', () => {
     cy.get('#element31').clear().blur();
 
     cy
-      .get('#form-section-7 > .form-section-buttons > .form-section-next')
+      .get('#form-section-7 > .form-section-buttons > .form-submit-button')
       .click();
     cy.get('.required-text').should('be.visible');
 
@@ -191,7 +191,7 @@ describe('senior required fields', () => {
     cy.get('#element33').clear().blur();
 
     cy
-      .get('#form-section-7 > .form-section-buttons > .form-section-next')
+      .get('#form-section-7 > .form-section-buttons > .form-submit-button')
       .click();
     cy.get('.required-text').should('be.visible');
   });

--- a/cypress/automated-tests/senior/required-fields.spec.js
+++ b/cypress/automated-tests/senior/required-fields.spec.js
@@ -23,11 +23,16 @@ describe('senior required fields', () => {
     cy
       .get('#form-section-0 > .form-section-buttons > .form-section-next')
       .click();
+
+    // Instructions
+    cy
+      .get('#form-section-1 > .form-section-buttons > .form-section-next')
+      .click();
   });
 
   it("does not fill in the application type and sees an error", function() {
     cy
-      .get('#form-section-1 > .form-section-buttons > .form-submit-button')
+      .get('#form-section-2 > .form-section-buttons > .form-submit-button')
       .click()
 
     cy.get('.required-text').should('be.visible');
@@ -37,9 +42,6 @@ describe('senior required fields', () => {
     cy
       .get('[data-field-code="ApplicantStatus"]')
       .contains('Apply for a Senior CharlieCard')
-      .click();
-    cy
-      .get('#form-section-1 > .form-section-buttons > .form-section-next')
       .click();
     cy
       .get('#form-section-2 > .form-section-buttons > .form-section-next')
@@ -83,6 +85,7 @@ describe('senior required fields', () => {
     cy
       .get('#form-section-3 > .form-section-buttons > .form-section-next')
       .click();
+    // Skip the optional Contact Information screen
     cy
       .get('#form-section-4 > .form-section-buttons > .form-section-next')
       .click();
@@ -142,7 +145,7 @@ describe('senior required fields', () => {
     cy.get('#element22').clear().blur();
 
     cy
-      .get('#form-section-7 > .form-section-buttons > .form-submit-button')
+      .get('#form-section-7 > .form-section-buttons > .form-section-next')
       .click();
     cy.get('.required-text').should('be.visible');
 
@@ -150,7 +153,7 @@ describe('senior required fields', () => {
     cy.get('#element24').clear().blur();
 
     cy
-      .get('#form-section-7 > .form-section-buttons > .form-submit-button')
+      .get('#form-section-7 > .form-section-buttons > .form-section-next')
       .click();
     cy.get('.required-text').should('be.visible');
 
@@ -158,7 +161,7 @@ describe('senior required fields', () => {
     cy.get('#element26').clear().blur();
 
     cy
-      .get('#form-section-7 > .form-section-buttons > .form-submit-button')
+      .get('#form-section-7 > .form-section-buttons > .form-section-next')
       .click();
     cy.get('.required-text').should('be.visible');
 
@@ -172,7 +175,7 @@ describe('senior required fields', () => {
     cy.get('#element33').type(applicantZipCode).blur();
 
     cy
-      .get('#form-section-7 > .form-section-buttons > .form-submit-button')
+      .get('#form-section-7 > .form-section-buttons > .form-section-next')
       .click();
     cy.get('.required-text').should('be.visible');
 
@@ -180,7 +183,7 @@ describe('senior required fields', () => {
     cy.get('#element31').clear().blur();
 
     cy
-      .get('#form-section-7 > .form-section-buttons > .form-submit-button')
+      .get('#form-section-7 > .form-section-buttons > .form-section-next')
       .click();
     cy.get('.required-text').should('be.visible');
 
@@ -188,7 +191,7 @@ describe('senior required fields', () => {
     cy.get('#element33').clear().blur();
 
     cy
-      .get('#form-section-7 > .form-section-buttons > .form-submit-button')
+      .get('#form-section-7 > .form-section-buttons > .form-section-next')
       .click();
     cy.get('.required-text').should('be.visible');
   });

--- a/cypress/automated-tests/senior/required-fields.spec.js
+++ b/cypress/automated-tests/senior/required-fields.spec.js
@@ -16,20 +16,18 @@ describe('senior required fields', () => {
     cy.visit(seniorUrl);
 
     // Language Selection
-    // Temporarily commented out while the language selection is hidden,
-    // per https://app.asana.com/0/1200240595613188/1201957412884505
-    // cy
-    //   .get('[data-field-code="LanguageSelection"]')
-    //   .contains('English')
-    //   .click();
-    // cy
-    //   .get('#form-section-0 > .form-section-buttons > .form-section-next')
-    //   .click();
+    cy
+      .get('[data-field-code="LanguageSelection"]')
+      .contains('English')
+      .click();
+    cy
+      .get('#form-section-0 > .form-section-buttons > .form-section-next')
+      .click();
   });
 
   it("does not fill in the application type and sees an error", function() {
     cy
-      .get('#form-section-0 > .form-section-buttons > .form-submit-button')
+      .get('#form-section-1 > .form-section-buttons > .form-submit-button')
       .click()
 
     cy.get('.required-text').should('be.visible');
@@ -41,10 +39,10 @@ describe('senior required fields', () => {
       .contains('Apply for a Senior CharlieCard')
       .click();
     cy
-      .get('#form-section-0 > .form-section-buttons > .form-section-next')
+      .get('#form-section-1 > .form-section-buttons > .form-section-next')
       .click();
     cy
-      .get('#form-section-1 > .form-section-buttons > .form-section-next')
+      .get('#form-section-2 > .form-section-buttons > .form-section-next')
       .click();
 
 
@@ -52,7 +50,7 @@ describe('senior required fields', () => {
     cy.get('#element13').type(applicantLastName).blur();
 
     cy
-      .get('#form-section-2 > .form-section-buttons > .form-submit-button')
+      .get('#form-section-3 > .form-section-buttons > .form-submit-button')
       .click();
     
     cy.get('.required-text').should('be.visible');
@@ -63,7 +61,7 @@ describe('senior required fields', () => {
     cy.get('#element12').clear().blur();
 
     cy
-      .get('#form-section-2 > .form-section-buttons > .form-submit-button')
+      .get('#form-section-3 > .form-section-buttons > .form-submit-button')
       .click();
     
     cy.get('.required-text').should('be.visible');
@@ -74,7 +72,7 @@ describe('senior required fields', () => {
     cy.get('#element13').clear().blur();
 
     cy
-      .get('#form-section-2 > .form-section-buttons > .form-submit-button')
+      .get('#form-section-3 > .form-section-buttons > .form-submit-button')
       .click();
     
     cy.get('.required-text').should('be.visible');
@@ -83,24 +81,8 @@ describe('senior required fields', () => {
   it("does not upload a photo ID and sees an error", function() {
     cy.get('#element13').type(applicantLastName).blur();
     cy
-      .get('#form-section-2 > .form-section-buttons > .form-section-next')
-      .click();
-    cy
       .get('#form-section-3 > .form-section-buttons > .form-section-next')
       .click();
-
-    cy
-      .get('#form-section-4 > .form-section-buttons > .form-submit-button')
-      .click();
-
-    cy.get('.required-text').should('be.visible');
-  });
-
-  it("does not upload a headshot and sees an error", function() {
-    cy
-      .get('#element36')
-      .attachFile('youth-pass-test-image.png');
-    cy.get('.k-text-success').should('exist');
     cy
       .get('#form-section-4 > .form-section-buttons > .form-section-next')
       .click();
@@ -112,13 +94,29 @@ describe('senior required fields', () => {
     cy.get('.required-text').should('be.visible');
   });
 
+  it("does not upload a headshot and sees an error", function() {
+    cy
+      .get('#element36')
+      .attachFile('youth-pass-test-image.png');
+    cy.get('.k-text-success').should('exist');
+    cy
+      .get('#form-section-5 > .form-section-buttons > .form-section-next')
+      .click();
+
+    cy
+      .get('#form-section-6 > .form-section-buttons > .form-submit-button')
+      .click();
+
+    cy.get('.required-text').should('be.visible');
+  });
+
   it("does not answer the delivery preference question and sees an error", function() {
     cy
       .get('#element39')
       .attachFile('youth-pass-test-image.png');
     cy.get('.k-text-success').should('exist');
     cy
-      .get('#form-section-5 > .form-section-buttons > .form-section-next')
+      .get('#form-section-6 > .form-section-buttons > .form-section-next')
       .click();
 
     cy.get('#element22').type(applicantStreetAddress).blur();
@@ -126,7 +124,7 @@ describe('senior required fields', () => {
     cy.get('#element26').type(applicantZipCode).blur();
 
     cy
-      .get('#form-section-6 > .form-section-buttons > .form-submit-button')
+      .get('#form-section-7 > .form-section-buttons > .form-submit-button')
       .click();
 
     cy.get('.required-text').should('be.visible');
@@ -144,7 +142,7 @@ describe('senior required fields', () => {
     cy.get('#element22').clear().blur();
 
     cy
-      .get('#form-section-6 > .form-section-buttons > .form-submit-button')
+      .get('#form-section-7 > .form-section-buttons > .form-submit-button')
       .click();
     cy.get('.required-text').should('be.visible');
 
@@ -152,7 +150,7 @@ describe('senior required fields', () => {
     cy.get('#element24').clear().blur();
 
     cy
-      .get('#form-section-6 > .form-section-buttons > .form-submit-button')
+      .get('#form-section-7 > .form-section-buttons > .form-submit-button')
       .click();
     cy.get('.required-text').should('be.visible');
 
@@ -160,7 +158,7 @@ describe('senior required fields', () => {
     cy.get('#element26').clear().blur();
 
     cy
-      .get('#form-section-6 > .form-section-buttons > .form-submit-button')
+      .get('#form-section-7 > .form-section-buttons > .form-submit-button')
       .click();
     cy.get('.required-text').should('be.visible');
 
@@ -174,7 +172,7 @@ describe('senior required fields', () => {
     cy.get('#element33').type(applicantZipCode).blur();
 
     cy
-      .get('#form-section-6 > .form-section-buttons > .form-submit-button')
+      .get('#form-section-7 > .form-section-buttons > .form-submit-button')
       .click();
     cy.get('.required-text').should('be.visible');
 
@@ -182,7 +180,7 @@ describe('senior required fields', () => {
     cy.get('#element31').clear().blur();
 
     cy
-      .get('#form-section-6 > .form-section-buttons > .form-submit-button')
+      .get('#form-section-7 > .form-section-buttons > .form-submit-button')
       .click();
     cy.get('.required-text').should('be.visible');
 
@@ -190,7 +188,7 @@ describe('senior required fields', () => {
     cy.get('#element33').clear().blur();
 
     cy
-      .get('#form-section-6 > .form-section-buttons > .form-submit-button')
+      .get('#form-section-7 > .form-section-buttons > .form-submit-button')
       .click();
     cy.get('.required-text').should('be.visible');
   });
@@ -198,14 +196,14 @@ describe('senior required fields', () => {
   it("does not agree to the rules and sees an error", function() {
     cy.get('#element33').type(applicantZipCode).blur();
     cy
-      .get('#form-section-6 > .form-section-buttons > .form-section-next')
+      .get('#form-section-7 > .form-section-buttons > .form-section-next')
       .click();
     cy
-      .get('#form-section-7 > .form-section-buttons > .form-section-next')
+      .get('#form-section-8 > .form-section-buttons > .form-section-next')
       .click();
 
     cy
-      .get('#form-section-8 > .form-section-buttons > .form-submit-button')
+      .get('#form-section-9 > .form-section-buttons > .form-submit-button')
       .click();
     cy.get('.required-text').should('be.visible');
   });

--- a/cypress/automated-tests/senior/successful-senior-submission.spec.js
+++ b/cypress/automated-tests/senior/successful-senior-submission.spec.js
@@ -168,7 +168,21 @@ describe('senior successful renewal submission - without an email address', () =
       .click();
   });
 
-  it("skips uploading a headshot", function() {
+  it("uploads a photo ID", function() {
+    cy
+      .get('#element36')
+      .attachFile('youth-pass-test-image.png');
+    cy.get('.k-text-success').should('exist');
+    cy
+      .get('#form-section-5 > .form-section-buttons > .form-section-next')
+      .click();
+  });
+
+  it("uploads a headshot", function() {
+    cy
+      .get('#element39')
+      .attachFile('youth-pass-test-image.png');
+    cy.get('.k-text-success').should('exist');
     cy
       .get('#form-section-6 > .form-section-buttons > .form-section-next')
       .click();

--- a/cypress/automated-tests/senior/successful-senior-submission.spec.js
+++ b/cypress/automated-tests/senior/successful-senior-submission.spec.js
@@ -9,17 +9,15 @@ describe('senior successful new submission - with an email address', () => {
     cy.visit(seniorUrl);
   });
 
-  // Temporarily commented out while the language selection is hidden,
-  // per https://app.asana.com/0/1200240595613188/1201957412884505
-  // it('completes the language selection', () => {
-  //   cy
-  //     .get('[data-field-code="LanguageSelection"]')
-  //     .contains('English')
-  //     .click();
-  //   cy
-  //     .get('#form-section-0 > .form-section-buttons > .form-section-next')
-  //     .click();
-  // });
+  it('completes the language selection', () => {
+    cy
+      .get('[data-field-code="LanguageSelection"]')
+      .contains('English')
+      .click();
+    cy
+      .get('#form-section-0 > .form-section-buttons > .form-section-next')
+      .click();
+  });
 
   it("selects apply for a new card", function() {
     cy
@@ -27,13 +25,13 @@ describe('senior successful new submission - with an email address', () => {
       .contains('Apply for a Senior CharlieCard')
       .click();
     cy
-      .get('#form-section-0 > .form-section-buttons > .form-section-next')
+      .get('#form-section-1 > .form-section-buttons > .form-section-next')
       .click();
   });
 
   it("clicks through instructions", function() {
     cy
-      .get('#form-section-1 > .form-section-buttons > .form-section-next')
+      .get('#form-section-2 > .form-section-buttons > .form-section-next')
       .click();
   });
 
@@ -46,7 +44,7 @@ describe('senior successful new submission - with an email address', () => {
     cy.get('#element12').type(applicantFirstName).blur();
     cy.get('#element13').type(applicantLastName).blur();
     cy
-      .get('#form-section-2 > .form-section-buttons > .form-section-next')
+      .get('#form-section-3 > .form-section-buttons > .form-section-next')
       .click();
   });
 
@@ -57,7 +55,7 @@ describe('senior successful new submission - with an email address', () => {
     cy.get('#element15').type(applicantPhoneNumber).blur();
     cy.get('#element16').type(applicantEmailAddress).blur();
     cy
-      .get('#form-section-3 > .form-section-buttons > .form-section-next')
+      .get('#form-section-4 > .form-section-buttons > .form-section-next')
       .click();
   });
 
@@ -67,7 +65,7 @@ describe('senior successful new submission - with an email address', () => {
       .attachFile('youth-pass-test-image.png');
     cy.get('.k-text-success').should('exist');
     cy
-      .get('#form-section-4 > .form-section-buttons > .form-section-next')
+      .get('#form-section-5 > .form-section-buttons > .form-section-next')
       .click();
   });
 
@@ -77,7 +75,7 @@ describe('senior successful new submission - with an email address', () => {
       .attachFile('youth-pass-test-image.png');
     cy.get('.k-text-success').should('exist');
     cy
-      .get('#form-section-5 > .form-section-buttons > .form-section-next')
+      .get('#form-section-6 > .form-section-buttons > .form-section-next')
       .click();
   });
 
@@ -97,20 +95,20 @@ describe('senior successful new submission - with an email address', () => {
       .contains('Yes')
       .click();
     cy
-      .get('#form-section-6 > .form-section-buttons > .form-section-next')
+      .get('#form-section-7 > .form-section-buttons > .form-section-next')
       .click();
   });
 
   it("skips the demographic section and agrees to the rules", function() {
     cy
-      .get('#form-section-7 > .form-section-buttons > .form-section-next')
+      .get('#form-section-8 > .form-section-buttons > .form-section-next')
       .click();
     cy
       .get('[data-field-code="RulesAndConditionsCheckbox"]')
       .contains('I agree')
       .click();
     cy
-      .get('#form-section-8 > .form-section-buttons > .form-submit-button')
+      .get('#form-section-9 > .form-section-buttons > .form-submit-button')
       .click();
 
     cy
@@ -125,17 +123,15 @@ describe('senior successful renewal submission - without an email address', () =
     cy.visit(seniorUrl);
   });
 
-  // Temporarily commented out while the language selection is hidden,
-  // per https://app.asana.com/0/1200240595613188/1201957412884505
-  // it('completes the language selection', () => {
-  //   cy
-  //     .get('[data-field-code="LanguageSelection"]')
-  //     .contains('English')
-  //     .click();
-  //   cy
-  //     .get('#form-section-0 > .form-section-buttons > .form-section-next')
-  //     .click();
-  // });
+  it('completes the language selection', () => {
+    cy
+      .get('[data-field-code="LanguageSelection"]')
+      .contains('English')
+      .click();
+    cy
+      .get('#form-section-0 > .form-section-buttons > .form-section-next')
+      .click();
+  });
 
   it("selects renew my card", function() {
     cy
@@ -143,7 +139,7 @@ describe('senior successful renewal submission - without an email address', () =
       .contains('Renew')
       .click();
     cy
-      .get('#form-section-0 > .form-section-buttons > .form-section-next')
+      .get('#form-section-1 > .form-section-buttons > .form-section-next')
       .click();
   });
 
@@ -156,19 +152,19 @@ describe('senior successful renewal submission - without an email address', () =
     cy.get('#element12').type(applicantFirstName).blur();
     cy.get('#element13').type(applicantLastName).blur();
     cy
-      .get('#form-section-2 > .form-section-buttons > .form-section-next')
+      .get('#form-section-3 > .form-section-buttons > .form-section-next')
       .click();
   });
 
   it("does not enter an email address or phone number for contact info", function() {
     cy
-      .get('#form-section-3 > .form-section-buttons > .form-section-next')
+      .get('#form-section-4 > .form-section-buttons > .form-section-next')
       .click();
   });
 
   it("skips uploading a headshot", function() {
     cy
-      .get('#form-section-5 > .form-section-buttons > .form-section-next')
+      .get('#form-section-6 > .form-section-buttons > .form-section-next')
       .click();
   });
 
@@ -188,20 +184,20 @@ describe('senior successful renewal submission - without an email address', () =
       .contains('Yes')
       .click();
     cy
-      .get('#form-section-6 > .form-section-buttons > .form-section-next')
+      .get('#form-section-7 > .form-section-buttons > .form-section-next')
       .click();
   });
 
   it("skips the demographic section and agrees to the rules", function() {
     cy
-      .get('#form-section-7 > .form-section-buttons > .form-section-next')
+      .get('#form-section-8 > .form-section-buttons > .form-section-next')
       .click();
     cy
       .get('[data-field-code="RulesAndConditionsCheckbox"]')
       .contains('I agree')
       .click();
     cy
-      .get('#form-section-8 > .form-section-buttons > .form-submit-button')
+      .get('#form-section-9 > .form-section-buttons > .form-submit-button')
       .click();
 
     cy

--- a/cypress/automated-tests/senior/successful-senior-submission.spec.js
+++ b/cypress/automated-tests/senior/successful-senior-submission.spec.js
@@ -19,17 +19,17 @@ describe('senior successful new submission - with an email address', () => {
       .click();
   });
 
-  it("selects apply for a new card", function() {
-    cy
-      .get('[data-field-code="ApplicantStatus"]')
-      .contains('Apply for a Senior CharlieCard')
-      .click();
+  it("clicks through instructions", function() {
     cy
       .get('#form-section-1 > .form-section-buttons > .form-section-next')
       .click();
   });
 
-  it("clicks through instructions", function() {
+  it("selects apply for a new card", function() {
+    cy
+      .get('[data-field-code="ApplicantStatus"]')
+      .contains('Apply for a Senior CharlieCard')
+      .click();
     cy
       .get('#form-section-2 > .form-section-buttons > .form-section-next')
       .click();
@@ -133,13 +133,19 @@ describe('senior successful renewal submission - without an email address', () =
       .click();
   });
 
+  it("clicks through instructions", function() {
+    cy
+      .get('#form-section-1 > .form-section-buttons > .form-section-next')
+      .click();
+  });
+
   it("selects renew my card", function() {
     cy
       .get('[data-field-code="ApplicantStatus"]')
       .contains('Renew')
       .click();
     cy
-      .get('#form-section-1 > .form-section-buttons > .form-section-next')
+      .get('#form-section-2 > .form-section-buttons > .form-section-next')
       .click();
   });
 


### PR DESCRIPTION
fix(test): Adjust tests to match new location of instruction screen

I noticed that the Senior tests were failing. Unfortunately they are still failing due to an [actual bug in the form](https://app.asana.com/0/1200856713913621/1202220086281291). ([example failure](https://github.com/mbta/reduced_fares/runs/6278655902?check_suite_focus=true))