### PR TITLE
Restore running senior tests in prod

### DIFF
--- a/.github/workflows/automation-prod.yml
+++ b/.github/workflows/automation-prod.yml
@@ -12,4 +12,4 @@ jobs:
         uses: cypress-io/github-action@v2
         with:
           env: youth_pass_url=https://mbta.prod.simpligov.com/prod/portal/ShowWorkFlow/AnonymousEmbed/e5e2dba6-5424-48d6-80d9-16a27e0fdd84
-          spec: cypress/automated-tests/youth-pass/address-section-required-fields.spec.js,cypress/automated-tests/youth-pass/eligibility-checker-blockers.spec.js,cypress/automated-tests/youth-pass/file-type-upload.spec.js,cypress/automated-tests/youth-pass/personal-contact-sections-required-fields.spec.js,cypress/automated-tests/youth-pass/successful-youth-pass-submission.spec.js
+          spec: cypress/automated-tests/youth-pass/address-section-required-fields.spec.js,cypress/automated-tests/youth-pass/eligibility-checker-blockers.spec.js,cypress/automated-tests/youth-pass/file-type-upload.spec.js,cypress/automated-tests/youth-pass/personal-contact-sections-required-fields.spec.js,cypress/automated-tests/youth-pass/successful-youth-pass-submission.spec.js,cypress/automated-tests/senior/birth-date-validation.spec.js,cypress/automated-tests/senior/required-fields.spec.js

--- a/.github/workflows/automation-prod.yml
+++ b/.github/workflows/automation-prod.yml
@@ -11,5 +11,5 @@ jobs:
       - name: Integration tests / Cypress
         uses: cypress-io/github-action@v2
         with:
-          env: youth_pass_url=https://mbta.prod.simpligov.com/prod/portal/ShowWorkFlow/AnonymousEmbed/e5e2dba6-5424-48d6-80d9-16a27e0fdd84
+          env: youth_pass_url=https://mbta.prod.simpligov.com/prod/portal/ShowWorkFlow/AnonymousEmbed/e5e2dba6-5424-48d6-80d9-16a27e0fdd84,senior_url=https://mbta.prod.simpligov.com/prod/portal/ShowWorkFlow/AnonymousEmbed/fc6ff5b0-f3bd-436d-8201-b6a4b98bc7fa
           spec: cypress/automated-tests/youth-pass/address-section-required-fields.spec.js,cypress/automated-tests/youth-pass/eligibility-checker-blockers.spec.js,cypress/automated-tests/youth-pass/file-type-upload.spec.js,cypress/automated-tests/youth-pass/personal-contact-sections-required-fields.spec.js,cypress/automated-tests/youth-pass/successful-youth-pass-submission.spec.js,cypress/automated-tests/senior/birth-date-validation.spec.js,cypress/automated-tests/senior/required-fields.spec.js


### PR DESCRIPTION
Asana ticket: [Restore running senior tests in prod](https://app.asana.com/0/1201449220161667/1202219930067647)

• Revert "fix: Stop running senior tests in prod for now (#74)"
2a30e1152e89254688bd7fb2cd04c0f4cc44526b

• fix: Specify the production Senior URL

~~Depends on the fix for [Senior: Home address not actually being required](https://app.asana.com/0/1200240595613188/1202220086281291) being deployed to production.~~