### PR TITLE
Fix: Skip tests requiring SimpliGov sign-in

### DIFF
--- a/cypress/automated-tests/youth-pass/admin-application-visibility.spec.js
+++ b/cypress/automated-tests/youth-pass/admin-application-visibility.spec.js
@@ -1,6 +1,6 @@
 import { submitApplication } from '../../common/submit-application';
 
-describe('Youth Pass Admin Application Visibility', () => {
+describe.skip('Youth Pass Admin Application Visibility', () => {
     const faker = require('faker');
     const maldenApplicantFirstName = faker.name.firstName();
     const maldenApplicantLastName = faker.name.lastName();

--- a/cypress/automated-tests/youth-pass/document-viewer-s3-urls.spec.js
+++ b/cypress/automated-tests/youth-pass/document-viewer-s3-urls.spec.js
@@ -1,6 +1,6 @@
 import { submitApplication } from '../../common/submit-application';
 
-describe('Youth Pass Document Viewer S3 URL Visibility', () => {
+describe.skip('Youth Pass Document Viewer S3 URL Visibility', () => {
     const faker = require('faker');
     const applicantFirstName = faker.name.firstName();
     const applicantLastName = faker.name.lastName();


### PR DESCRIPTION
Small PR to skip the two tests that require signing into SimpliGov PreProd. This sign-in functionality needs to be reworked following the implementation of SSO for PreProd. 

Asana task for the functionality investigation [is here](https://app.asana.com/0/1170867711449497/1202217735562326/f), and follow-up task to restore these tests [is here](https://app.asana.com/0/1170867711449497/1202220573692328/f).  