### PR TITLE
Fix: Restore production scripts

### DIFF
--- a/.github/workflows/automation-prod.yml
+++ b/.github/workflows/automation-prod.yml
@@ -1,11 +1,7 @@
 name: Cypress Automation Production Testing
-on: 
-  push:
-    branches:    
-      - 'fix-prod-scripts-krj'
-# on:
-  # schedule:
-  #   - cron: "0 5 * * *" # run at 5 AM UTC
+on:
+  schedule:
+    - cron: "0 5 * * *" # run at 5 AM UTC
 jobs:
   cypress-prod:
     runs-on: ubuntu-latest

--- a/.github/workflows/automation-prod.yml
+++ b/.github/workflows/automation-prod.yml
@@ -1,7 +1,8 @@
 name: Cypress Automation Production Testing
-on:
-  schedule:
-    - cron: "0 5 * * *" # run at 5 AM UTC
+on: workflow_dispatch
+# on:
+  # schedule:
+  #   - cron: "0 5 * * *" # run at 5 AM UTC
 jobs:
   cypress-prod:
     runs-on: ubuntu-latest
@@ -9,7 +10,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
       - name: Integration tests / Cypress
-        uses: cypress-io/github-action@v2
+        uses: cypress-io/github-action@v4
         with:
           env: youth_pass_url=https://mbta.prod.simpligov.com/prod/portal/ShowWorkFlow/AnonymousEmbed/e5e2dba6-5424-48d6-80d9-16a27e0fdd84,senior_url=https://mbta.prod.simpligov.com/prod/portal/ShowWorkFlow/AnonymousEmbed/fc6ff5b0-f3bd-436d-8201-b6a4b98bc7fa
           spec: cypress/automated-tests/youth-pass/address-section-required-fields.cy.js,cypress/automated-tests/youth-pass/eligibility-checker-blockers.cy.js,cypress/automated-tests/youth-pass/file-type-upload.cy.js,cypress/automated-tests/youth-pass/personal-contact-sections-required-fields.cy.js,cypress/automated-tests/youth-pass/successful-youth-pass-submission.cy.js,cypress/automated-tests/senior/birth-date-validation.cy.js,cypress/automated-tests/senior/required-fields.cy.js

--- a/.github/workflows/automation-prod.yml
+++ b/.github/workflows/automation-prod.yml
@@ -1,5 +1,8 @@
 name: Cypress Automation Production Testing
-on: workflow_dispatch
+on: 
+  push:
+    branches:    
+      - 'fix-prod-scripts-krj'
 # on:
   # schedule:
   #   - cron: "0 5 * * *" # run at 5 AM UTC


### PR DESCRIPTION
The Cypress Production run failed overnight following an upgrade to Cypress 10. This PR updates the checkout action in the Production script to allow the tests to run. Sample run [shown here](https://github.com/mbta/reduced_fares/actions/runs/2468827656). 

No Asana task. 