### PR TITLE
Feat: Retry Failing Tests

### DIFF
--- a/cypress.config.js
+++ b/cypress.config.js
@@ -5,6 +5,7 @@ module.exports = defineConfig({
   video: false,
   screenshotOnRunFailure: false,
   chromeWebSecurity: false,
+  retries: 2,
   env: {
     youth_pass_url:
       'https://mbta.preprod.simpligov.com/preprod/portal/ShowWorkFlow/AnonymousEmbed/86cadfa6-e8ea-46f1-b6e8-62498f066962',
@@ -22,5 +23,5 @@ module.exports = defineConfig({
       return require('./cypress/plugins/index.js')(on, config)
     },
     specPattern: 'cypress/automated-tests/**/*.cy.{js,jsx,ts,tsx}',
-  },
+  }
 })

--- a/cypress/automated-tests/youth-pass/address-section-required-fields.cy.js
+++ b/cypress/automated-tests/youth-pass/address-section-required-fields.cy.js
@@ -5,7 +5,7 @@ describe('Youth Pass Address Section Required Fields', () => {
     
     // this test follows the by mail flow
     it('proceeds through an application', () => {
-        const applicantZipCode = '01545';
+        const applicantZipCode = '02114';
         const youthPassUrl = Cypress.env('youth_pass_url');
         const applicantBirthdate = getRandomApplicantAge().applicantBirthdate12to17;
         const applicantSchoolName = `Automation Testing ${faker.datatype.number()} School`;

--- a/cypress/automated-tests/youth-pass/address-section-required-fields.cy.js
+++ b/cypress/automated-tests/youth-pass/address-section-required-fields.cy.js
@@ -5,7 +5,7 @@ describe('Youth Pass Address Section Required Fields', () => {
     
     // this test follows the by mail flow
     it('proceeds through an application', () => {
-        const applicantZipCode = '02114';
+        const applicantZipCode = '01545';
         const youthPassUrl = Cypress.env('youth_pass_url');
         const applicantBirthdate = getRandomApplicantAge().applicantBirthdate12to17;
         const applicantSchoolName = `Automation Testing ${faker.datatype.number()} School`;


### PR DESCRIPTION
The Production automation runs have been failing randomly overnight, but they always pass on retry. This is leading to a lot of false negatives and some unnecessary investigation work in the mornings. 

This PR adds a retry value of 2 to the Cypress configuration. Each test will retry failures twice (for a total of 3 attempts). This should help us diagnose actual failures faster and with more confidence. 

No Asana task. I introduced an intentional failure to the repo as roof of concept:
![Screen Shot 2022-08-16 at 9 48 14 AM](https://user-images.githubusercontent.com/49254078/184896811-bd60eac8-7c37-47c9-84c3-b683f6d4d598.png)

