### PR TITLE
hide calendar

### DIFF
--- a/build/stylesheets/blind.css
+++ b/build/stylesheets/blind.css
@@ -36,7 +36,7 @@ figcaption {
   p,
 li,
 figcaption {
-    font-size: 0.85rem !important;
+    font-size: 0.875rem !important;
   }
 }
 h1,
@@ -97,7 +97,7 @@ h4 {
 }
 
 /* Hide calendar */
-.datetimepicker.datetimepicker-dropdown-bottom-right.dropdown-menu {
+.datetimepicker {
   display: none !important;
 }
 
@@ -115,7 +115,7 @@ h4 {
 
 @media (max-width: 799px) {
   .form-label {
-    font-size: 0.85rem !important;
+    font-size: 0.875rem !important;
   }
 }
 /* Bold all labels except Boolean checkbox */
@@ -138,7 +138,7 @@ h4 {
 
 @media (max-width: 799px) {
   .sub-heading {
-    font-size: 0.85rem !important;
+    font-size: 0.875rem !important;
   }
 }
 /* Form field error message styling */
@@ -157,7 +157,7 @@ h4 {
 .requiredLabelEmail,
 .regexErrorLabel,
 .datePickerFormatError {
-    font-size: 0.85rem !important;
+    font-size: 0.875rem !important;
   }
 }
 /* Position form field error messages */
@@ -221,7 +221,7 @@ input[type=text].textfield:focus {
 .k-file-name,
 .k-file-size,
 .k-file-validation-message {
-    font-size: 0.85rem !important;
+    font-size: 0.875rem !important;
   }
 }
 /* Make upload light gray color darker */
@@ -251,7 +251,7 @@ input[type=text].textfield:focus {
 
 @media (max-width: 799px) {
   .k-file-invalid .k-file-validation-message {
-    font-size: 0.85rem !important;
+    font-size: 0.875rem !important;
   }
 }
 /* Make upload "invalid files" error message darker */
@@ -263,7 +263,7 @@ input[type=text].textfield:focus {
 
 @media (max-width: 799px) {
   .validation-text.fileUploadErrorLabel.truncateWithEllipsis {
-    font-size: 0.85rem !important;
+    font-size: 0.875rem !important;
   }
 }
 /* Modal error support for small screens */

--- a/build/stylesheets/senior.css
+++ b/build/stylesheets/senior.css
@@ -36,7 +36,7 @@ figcaption {
   p,
 li,
 figcaption {
-    font-size: 0.85rem !important;
+    font-size: 0.875rem !important;
   }
 }
 h1,
@@ -97,7 +97,7 @@ h4 {
 }
 
 /* Hide calendar */
-.datetimepicker.datetimepicker-dropdown-bottom-right.dropdown-menu {
+.datetimepicker {
   display: none !important;
 }
 
@@ -115,7 +115,7 @@ h4 {
 
 @media (max-width: 799px) {
   .form-label {
-    font-size: 0.85rem !important;
+    font-size: 0.875rem !important;
   }
 }
 /* Bold all labels except Boolean checkbox */
@@ -138,7 +138,7 @@ h4 {
 
 @media (max-width: 799px) {
   .sub-heading {
-    font-size: 0.85rem !important;
+    font-size: 0.875rem !important;
   }
 }
 /* Form field error message styling */
@@ -157,7 +157,7 @@ h4 {
 .requiredLabelEmail,
 .regexErrorLabel,
 .datePickerFormatError {
-    font-size: 0.85rem !important;
+    font-size: 0.875rem !important;
   }
 }
 /* Position form field error messages */
@@ -221,7 +221,7 @@ input[type=text].textfield:focus {
 .k-file-name,
 .k-file-size,
 .k-file-validation-message {
-    font-size: 0.85rem !important;
+    font-size: 0.875rem !important;
   }
 }
 /* Make upload light gray color darker */
@@ -251,7 +251,7 @@ input[type=text].textfield:focus {
 
 @media (max-width: 799px) {
   .k-file-invalid .k-file-validation-message {
-    font-size: 0.85rem !important;
+    font-size: 0.875rem !important;
   }
 }
 /* Make upload "invalid files" error message darker */
@@ -263,7 +263,7 @@ input[type=text].textfield:focus {
 
 @media (max-width: 799px) {
   .validation-text.fileUploadErrorLabel.truncateWithEllipsis {
-    font-size: 0.85rem !important;
+    font-size: 0.875rem !important;
   }
 }
 /* Modal error support for small screens */

--- a/build/stylesheets/tap.css
+++ b/build/stylesheets/tap.css
@@ -36,7 +36,7 @@ figcaption {
   p,
 li,
 figcaption {
-    font-size: 0.85rem !important;
+    font-size: 0.875rem !important;
   }
 }
 h1,
@@ -97,7 +97,7 @@ h4 {
 }
 
 /* Hide calendar */
-.datetimepicker.datetimepicker-dropdown-bottom-right.dropdown-menu {
+.datetimepicker {
   display: none !important;
 }
 
@@ -115,7 +115,7 @@ h4 {
 
 @media (max-width: 799px) {
   .form-label {
-    font-size: 0.85rem !important;
+    font-size: 0.875rem !important;
   }
 }
 /* Bold all labels except Boolean checkbox */
@@ -138,7 +138,7 @@ h4 {
 
 @media (max-width: 799px) {
   .sub-heading {
-    font-size: 0.85rem !important;
+    font-size: 0.875rem !important;
   }
 }
 /* Form field error message styling */
@@ -157,7 +157,7 @@ h4 {
 .requiredLabelEmail,
 .regexErrorLabel,
 .datePickerFormatError {
-    font-size: 0.85rem !important;
+    font-size: 0.875rem !important;
   }
 }
 /* Position form field error messages */
@@ -221,7 +221,7 @@ input[type=text].textfield:focus {
 .k-file-name,
 .k-file-size,
 .k-file-validation-message {
-    font-size: 0.85rem !important;
+    font-size: 0.875rem !important;
   }
 }
 /* Make upload light gray color darker */
@@ -251,7 +251,7 @@ input[type=text].textfield:focus {
 
 @media (max-width: 799px) {
   .k-file-invalid .k-file-validation-message {
-    font-size: 0.85rem !important;
+    font-size: 0.875rem !important;
   }
 }
 /* Make upload "invalid files" error message darker */
@@ -263,7 +263,7 @@ input[type=text].textfield:focus {
 
 @media (max-width: 799px) {
   .validation-text.fileUploadErrorLabel.truncateWithEllipsis {
-    font-size: 0.85rem !important;
+    font-size: 0.875rem !important;
   }
 }
 /* Modal error support for small screens */

--- a/build/stylesheets/youth.css
+++ b/build/stylesheets/youth.css
@@ -36,7 +36,7 @@ figcaption {
   p,
 li,
 figcaption {
-    font-size: 0.85rem !important;
+    font-size: 0.875rem !important;
   }
 }
 h1,
@@ -97,7 +97,7 @@ h4 {
 }
 
 /* Hide calendar */
-.datetimepicker.datetimepicker-dropdown-bottom-right.dropdown-menu {
+.datetimepicker {
   display: none !important;
 }
 
@@ -115,7 +115,7 @@ h4 {
 
 @media (max-width: 799px) {
   .form-label {
-    font-size: 0.85rem !important;
+    font-size: 0.875rem !important;
   }
 }
 /* Bold all labels except Boolean checkbox */
@@ -138,7 +138,7 @@ h4 {
 
 @media (max-width: 799px) {
   .sub-heading {
-    font-size: 0.85rem !important;
+    font-size: 0.875rem !important;
   }
 }
 /* Form field error message styling */
@@ -157,7 +157,7 @@ h4 {
 .requiredLabelEmail,
 .regexErrorLabel,
 .datePickerFormatError {
-    font-size: 0.85rem !important;
+    font-size: 0.875rem !important;
   }
 }
 /* Position form field error messages */
@@ -221,7 +221,7 @@ input[type=text].textfield:focus {
 .k-file-name,
 .k-file-size,
 .k-file-validation-message {
-    font-size: 0.85rem !important;
+    font-size: 0.875rem !important;
   }
 }
 /* Make upload light gray color darker */
@@ -251,7 +251,7 @@ input[type=text].textfield:focus {
 
 @media (max-width: 799px) {
   .k-file-invalid .k-file-validation-message {
-    font-size: 0.85rem !important;
+    font-size: 0.875rem !important;
   }
 }
 /* Make upload "invalid files" error message darker */
@@ -263,7 +263,7 @@ input[type=text].textfield:focus {
 
 @media (max-width: 799px) {
   .validation-text.fileUploadErrorLabel.truncateWithEllipsis {
-    font-size: 0.85rem !important;
+    font-size: 0.875rem !important;
   }
 }
 /* Modal error support for small screens */

--- a/stylesheets/common/_base.scss
+++ b/stylesheets/common/_base.scss
@@ -38,7 +38,7 @@ figcaption {
   p,
   li,
   figcaption {
-    font-size: 0.85rem !important;
+    font-size: 0.875rem !important;
   }
 }
 
@@ -104,7 +104,7 @@ h4 {
 }
 
 /* Hide calendar */
-.datetimepicker.datetimepicker-dropdown-bottom-right.dropdown-menu {
+.datetimepicker {
   display: none !important;
 }
 
@@ -122,7 +122,7 @@ h4 {
 
 @media (max-width: 799px) {
   .form-label {
-    font-size: 0.85rem !important;
+    font-size: 0.875rem !important;
   }
 }
 
@@ -146,7 +146,7 @@ h4 {
 
 @media (max-width: 799px) {
   .sub-heading {
-    font-size: 0.85rem !important;
+    font-size: 0.875rem !important;
   }
 }
 
@@ -166,7 +166,7 @@ h4 {
   .requiredLabelEmail,
   .regexErrorLabel,
   .datePickerFormatError {
-    font-size: 0.85rem !important;
+    font-size: 0.875rem !important;
   }
 }
 
@@ -231,7 +231,7 @@ input[type="text"].textfield:focus {
   .k-file-name,
   .k-file-size,
   .k-file-validation-message {
-    font-size: 0.85rem !important;
+    font-size: 0.875rem !important;
   }
 }
 
@@ -262,7 +262,7 @@ input[type="text"].textfield:focus {
 
 @media (max-width: 799px) {
   .k-file-invalid .k-file-validation-message {
-    font-size: 0.85rem !important;
+    font-size: 0.875rem !important;
   }
 }
 
@@ -275,7 +275,7 @@ input[type="text"].textfield:focus {
 
 @media (max-width: 799px) {
   .validation-text.fileUploadErrorLabel.truncateWithEllipsis {
-    font-size: 0.85rem !important;
+    font-size: 0.875rem !important;
   }
 }
 


### PR DESCRIPTION
Asana tickets:

- [Update CSS to hide calendar](https://app.asana.com/0/1170867711449497/1202841812503975/f)
- [Update rem values on smaller screens](https://app.asana.com/0/1170867711449497/1202799016194917/f)

datetimepicker selector is simplified and is expected to hide the calendar in all cases. The previous CSS provided by SimpliGov did not consistently hide the calendar. SimpliGov does not expect this simplified CSS to cause any issues.