### PR TITLE
Fix: Allow manual runs for production automation tests

### DIFF
--- a/.github/workflows/automation-prod.yml
+++ b/.github/workflows/automation-prod.yml
@@ -1,5 +1,6 @@
 name: Cypress Automation Production Testing
 on:
+  workflow_dispatch:
   schedule:
     - cron: "0 5 * * *" # run at 5 AM UTC
 jobs:

--- a/package-lock.json
+++ b/package-lock.json
@@ -2927,9 +2927,9 @@
       "dev": true
     },
     "node_modules/sass": {
-      "version": "1.54.9",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.54.9.tgz",
-      "integrity": "sha512-xb1hjASzEH+0L0WI9oFjqhRi51t/gagWnxLiwUNMltA0Ab6jIDkAacgKiGYKM9Jhy109osM7woEEai6SXeJo5Q==",
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.55.0.tgz",
+      "integrity": "sha512-Pk+PMy7OGLs9WaxZGJMn7S96dvlyVBwwtToX895WmCpAOr5YiJYEUJfiJidMuKb613z2xNWcXCHEuOvjZbqC6A==",
       "dev": true,
       "dependencies": {
         "chokidar": ">=3.0.0 <4.0.0",
@@ -5755,9 +5755,9 @@
       "dev": true
     },
     "sass": {
-      "version": "1.54.9",
-      "resolved": "https://registry.npmjs.org/sass/-/sass-1.54.9.tgz",
-      "integrity": "sha512-xb1hjASzEH+0L0WI9oFjqhRi51t/gagWnxLiwUNMltA0Ab6jIDkAacgKiGYKM9Jhy109osM7woEEai6SXeJo5Q==",
+      "version": "1.55.0",
+      "resolved": "https://registry.npmjs.org/sass/-/sass-1.55.0.tgz",
+      "integrity": "sha512-Pk+PMy7OGLs9WaxZGJMn7S96dvlyVBwwtToX895WmCpAOr5YiJYEUJfiJidMuKb613z2xNWcXCHEuOvjZbqC6A==",
       "dev": true,
       "requires": {
         "chokidar": ">=3.0.0 <4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -3128,9 +3128,9 @@
       "dev": true
     },
     "node_modules/stylelint": {
-      "version": "14.12.0",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.12.0.tgz",
-      "integrity": "sha512-9Sa+IsT31PN9zf9q5ZVZNvhT6jMVu6YhpI38g3Akn7vONipGL0GNd9QCblwtJ3ysaoM80P/+9mOcFB1xnytiQQ==",
+      "version": "14.12.1",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.12.1.tgz",
+      "integrity": "sha512-ZEM4TuksChMBfuPadQsHUkbOoRySAT9QMfDvvYxdAchOJl0p+csTMBXOu6ORAAxKhwBmxqJiep8V88bXfNs3EQ==",
       "dev": true,
       "dependencies": {
         "@csstools/selector-specificity": "^2.0.2",
@@ -5909,9 +5909,9 @@
       "dev": true
     },
     "stylelint": {
-      "version": "14.12.0",
-      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.12.0.tgz",
-      "integrity": "sha512-9Sa+IsT31PN9zf9q5ZVZNvhT6jMVu6YhpI38g3Akn7vONipGL0GNd9QCblwtJ3ysaoM80P/+9mOcFB1xnytiQQ==",
+      "version": "14.12.1",
+      "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.12.1.tgz",
+      "integrity": "sha512-ZEM4TuksChMBfuPadQsHUkbOoRySAT9QMfDvvYxdAchOJl0p+csTMBXOu6ORAAxKhwBmxqJiep8V88bXfNs3EQ==",
       "dev": true,
       "requires": {
         "@csstools/selector-specificity": "^2.0.2",


### PR DESCRIPTION
This PR allows GitHub users with access to the Reduced Fares repository to run all automated tests against production via the manual `workflow_dispatch` trigger. 

Based on the [documentation](https://evanhalley.dev/post/github-actions-workflow-with-inputs/) I found, this appears to be the correct format. 

Asana task: https://app.asana.com/0/1113179098808463/1203037341140142/f