### PR TITLE
Fix: Remove no longer required field from script

### DIFF
--- a/cypress/automated-tests/blind/required-fields.cy.js
+++ b/cypress/automated-tests/blind/required-fields.cy.js
@@ -53,14 +53,6 @@ describe('blind required fields', () => {
       .should('be.visible');
   });
 
-
-  it("sees a required error for photo ID", function() {
-    cy
-      .get('#form-element-wrapper_25 > :nth-child(1) > [rcd=""] > .required-text')
-      .should('be.visible');
-  });
-
-
   it("sees a required error for headshot", function() {
     cy
       .get('#form-element-wrapper_30 > :nth-child(1) > [rcd=""] > .required-text')

--- a/cypress/automated-tests/blind/successful-blind-submission.cy.js
+++ b/cypress/automated-tests/blind/successful-blind-submission.cy.js
@@ -53,12 +53,12 @@ describe('blind successful new submission - with an email address', () => {
     cy.get('.k-text-success').should('exist');
   });
 
-  it("uploads a photo ID", function() {
-    cy
-      .get('#element25')
-      .attachFile('youth-pass-test-image.png');
-    cy.get('.k-text-success').should('exist');
-  });
+  // it("uploads a photo ID", function() {
+  //   cy
+  //     .get('#element25')
+  //     .attachFile('youth-pass-test-image.png');
+  //   cy.get('.k-text-success').should('exist');
+  // });
 
   it("uploads a headshot", function() {
     cy

--- a/cypress/automated-tests/blind/successful-blind-submission.cy.js
+++ b/cypress/automated-tests/blind/successful-blind-submission.cy.js
@@ -53,13 +53,6 @@ describe('blind successful new submission - with an email address', () => {
     cy.get('.k-text-success').should('exist');
   });
 
-  // it("uploads a photo ID", function() {
-  //   cy
-  //     .get('#element25')
-  //     .attachFile('youth-pass-test-image.png');
-  //   cy.get('.k-text-success').should('exist');
-  // });
-
   it("uploads a headshot", function() {
     cy
       .get('#element30')


### PR DESCRIPTION
This PR removes the photo ID field requirement from the blind-required-fields spec. This field is no longer required if a user provides an MCB ID, so the script was failing to find this element and breaking. With this change, we have a successful workflow run in [PreProd](https://github.com/mbta/reduced_fares/actions/runs/3160083166).

[Asana task](https://app.asana.com/0/1170867711449497/1203074321659822/f)