### PR TITLE
Fix: Restore youth pass automation tests

### DIFF
--- a/cypress/automated-tests/youth-pass/address-section-required-fields.cy.js
+++ b/cypress/automated-tests/youth-pass/address-section-required-fields.cy.js
@@ -28,6 +28,8 @@ describe('Youth Pass Address Section Required Fields', () => {
         cy.get('#form-section-3 > .form-section-buttons > .form-section-next').click();
         
         cy.get('#element116_Apply').click().blur();
+        // TODO: Remove line 32 when program year choice field is removed from SimpliGov
+        cy.get('#element260_Current').click().blur();
         cy.get('#element11').type(applicantFirstName).blur();
         cy.get('#element13').type(applicantLastName).blur();
         cy.get('#form-section-5 > .form-section-buttons > .form-section-next').click();

--- a/cypress/automated-tests/youth-pass/address-section-required-fields.cy.js
+++ b/cypress/automated-tests/youth-pass/address-section-required-fields.cy.js
@@ -1,4 +1,5 @@
 import { getRandomApplicantAge } from '../../common/birthdate-constants';
+import { ifExists } from '../../common/if-exists';
 
 describe('Youth Pass Address Section Required Fields', () => {
     const faker = require('faker');
@@ -28,8 +29,9 @@ describe('Youth Pass Address Section Required Fields', () => {
         cy.get('#form-section-3 > .form-section-buttons > .form-section-next').click();
         
         cy.get('#element116_Apply').click().blur();
-        // TODO: Remove line 32 when program year choice field is removed from SimpliGov
-        cy.get('#element260_Current').click().blur();
+        ifExists('#form-element-wrapper_260', () => {
+            cy.get('#element260_Current').click().blur();
+        });
         cy.get('#element11').type(applicantFirstName).blur();
         cy.get('#element13').type(applicantLastName).blur();
         cy.get('#form-section-5 > .form-section-buttons > .form-section-next').click();

--- a/cypress/automated-tests/youth-pass/personal-contact-sections-required-fields.cy.js
+++ b/cypress/automated-tests/youth-pass/personal-contact-sections-required-fields.cy.js
@@ -38,6 +38,10 @@ describe('Youth Pass Personal and Contact Info Section Required Fields', () => {
         cy.get('#form-element-wrapper_116').within(() => {
             cy.get('div.required-text').should('not.be.visible');
         });
+        // TODO: Remove lines 42-44 when program year choice field is removed from SimpliGov
+        cy.get('#form-element-wrapper_260').within(() => {
+            cy.get('div.required-text').should('be.visible');
+        });
         cy.get('#form-element-wrapper_11').within(() => {
             cy.get('div.required-text').should('be.visible');
         });
@@ -48,10 +52,15 @@ describe('Youth Pass Personal and Contact Info Section Required Fields', () => {
     
     it('does not fill last name and sees required field errors', () => {              
         const applicantFirstName = faker.name.firstName();
-
+        // TODO: Remove line 56 when program year choice field is removed from SimpliGov
+        cy.get('#element260_Current').click().blur();
         cy.get('#element11').type(applicantFirstName).blur();
         cy.get('#form-section-5 > .form-section-buttons > .form-submit-button').click();
         cy.get('#form-element-wrapper_11').within(() => {
+            cy.get('div.required-text').should('not.be.visible');
+        });
+        // TODO: Remove lines 63-65 when program year choice field is removed from SimpliGov
+        cy.get('#form-element-wrapper_260').within(() => {
             cy.get('div.required-text').should('not.be.visible');
         });
         cy.get('#form-element-wrapper_13').within(() => {

--- a/cypress/automated-tests/youth-pass/personal-contact-sections-required-fields.cy.js
+++ b/cypress/automated-tests/youth-pass/personal-contact-sections-required-fields.cy.js
@@ -1,4 +1,5 @@
 import { getRandomApplicantAge } from '../../common/birthdate-constants';
+import { ifExists } from '../../common/if-exists';
 
 describe('Youth Pass Personal and Contact Info Section Required Fields', () => {
     const faker = require('faker');
@@ -38,10 +39,6 @@ describe('Youth Pass Personal and Contact Info Section Required Fields', () => {
         cy.get('#form-element-wrapper_116').within(() => {
             cy.get('div.required-text').should('not.be.visible');
         });
-        // TODO: Remove lines 42-44 when program year choice field is removed from SimpliGov
-        cy.get('#form-element-wrapper_260').within(() => {
-            cy.get('div.required-text').should('be.visible');
-        });
         cy.get('#form-element-wrapper_11').within(() => {
             cy.get('div.required-text').should('be.visible');
         });
@@ -52,15 +49,18 @@ describe('Youth Pass Personal and Contact Info Section Required Fields', () => {
     
     it('does not fill last name and sees required field errors', () => {              
         const applicantFirstName = faker.name.firstName();
-        // TODO: Remove line 56 when program year choice field is removed from SimpliGov
-        cy.get('#element260_Current').click().blur();
+        ifExists('#form-element-wrapper_260', () => {
+            cy.get('#form-element-wrapper_260').within(() => {
+                cy.get('div.required-text').should('be.visible');
+            });
+            cy.get('#element260_Current').click().blur();
+            cy.get('#form-element-wrapper_260').within(() => {
+                cy.get('div.required-text').should('not.be.visible');
+            });
+        });
         cy.get('#element11').type(applicantFirstName).blur();
         cy.get('#form-section-5 > .form-section-buttons > .form-submit-button').click();
         cy.get('#form-element-wrapper_11').within(() => {
-            cy.get('div.required-text').should('not.be.visible');
-        });
-        // TODO: Remove lines 63-65 when program year choice field is removed from SimpliGov
-        cy.get('#form-element-wrapper_260').within(() => {
             cy.get('div.required-text').should('not.be.visible');
         });
         cy.get('#form-element-wrapper_13').within(() => {

--- a/cypress/automated-tests/youth-pass/successful-youth-pass-submission.cy.js
+++ b/cypress/automated-tests/youth-pass/successful-youth-pass-submission.cy.js
@@ -25,6 +25,8 @@ describe('Youth Pass Successful Submission', () => {
         const applicantLastName = faker.name.lastName();
 
         cy.get('#element116_Apply').click().blur();
+        // TODO: Remove line 29 when program year choice field is removed from SimpliGov
+        cy.get('#element260_Current').click().blur();
         cy.get('#element11').type(applicantFirstName).blur();
         cy.get('#element13').type(applicantLastName).blur();
         cy.get('#form-section-5 > .form-section-buttons > .form-section-next').click();

--- a/cypress/automated-tests/youth-pass/successful-youth-pass-submission.cy.js
+++ b/cypress/automated-tests/youth-pass/successful-youth-pass-submission.cy.js
@@ -1,4 +1,5 @@
 import { getRandomApplicantAge } from '../../common/birthdate-constants';
+import { ifExists } from '../../common/if-exists';
 
 describe('Youth Pass Successful Submission', () => {
     const faker = require('faker');
@@ -25,8 +26,9 @@ describe('Youth Pass Successful Submission', () => {
         const applicantLastName = faker.name.lastName();
 
         cy.get('#element116_Apply').click().blur();
-        // TODO: Remove line 29 when program year choice field is removed from SimpliGov
-        cy.get('#element260_Current').click().blur();
+        ifExists('#form-element-wrapper_260', () => {
+            cy.get('#element260_Current').click().blur();
+        });
         cy.get('#element11').type(applicantFirstName).blur();
         cy.get('#element13').type(applicantLastName).blur();
         cy.get('#form-section-5 > .form-section-buttons > .form-section-next').click();

--- a/cypress/common/if-exists.js
+++ b/cypress/common/if-exists.js
@@ -1,0 +1,15 @@
+/**
+ * Executes the callback only if the element exists on the page.
+ * 
+ * @callback ifExistsCallback
+ * 
+ * @param {string} element Selector string for an element on the page.
+ * @param {ifExistsCallback} callback Callback function to be executed only if the element exists.
+*/
+export function ifExists(element, callback) {
+  cy.get('body').then((body) => {
+    if (body.find(element).length > 0) {
+        callback();
+    }
+  });
+};


### PR DESCRIPTION
This PR adds a selection for the "Which program year..." field so the Youth Pass automation scripts will pass. Note that these changes should be reverted when this field is removed from SimpliGov (on/around October 15). With these changes, we've had a successful run of the [Prod automation scripts](https://github.com/mbta/reduced_fares/actions/runs/3175673238). 

No Asana task for fix. 

Asana task to remove these fields: https://app.asana.com/0/1170867711449497/1203091409919759/f