### PR TITLE
Fix: Adjust conditional logic to check date

### DIFF
--- a/cypress/automated-tests/youth-pass/address-section-required-fields.cy.js
+++ b/cypress/automated-tests/youth-pass/address-section-required-fields.cy.js
@@ -1,5 +1,5 @@
 import { getRandomApplicantAge } from '../../common/birthdate-constants';
-import { ifExists } from '../../common/if-exists';
+import { ifProgramYearFieldExists } from '../../common/if-exists';
 
 describe('Youth Pass Address Section Required Fields', () => {
     const faker = require('faker');
@@ -29,7 +29,7 @@ describe('Youth Pass Address Section Required Fields', () => {
         cy.get('#form-section-3 > .form-section-buttons > .form-section-next').click();
         
         cy.get('#element116_Apply').click().blur();
-        ifExists('#form-element-wrapper_260', () => {
+        ifProgramYearFieldExists(() => {
             cy.get('#element260_Current').click().blur();
         });
         cy.get('#element11').type(applicantFirstName).blur();

--- a/cypress/automated-tests/youth-pass/personal-contact-sections-required-fields.cy.js
+++ b/cypress/automated-tests/youth-pass/personal-contact-sections-required-fields.cy.js
@@ -1,5 +1,5 @@
 import { getRandomApplicantAge } from '../../common/birthdate-constants';
-import { ifExists } from '../../common/if-exists';
+import { ifProgramYearFieldExists } from '../../common/if-exists';
 
 describe('Youth Pass Personal and Contact Info Section Required Fields', () => {
     const faker = require('faker');
@@ -49,7 +49,7 @@ describe('Youth Pass Personal and Contact Info Section Required Fields', () => {
     
     it('does not fill last name and sees required field errors', () => {              
         const applicantFirstName = faker.name.firstName();
-        ifExists('#form-element-wrapper_260', () => {
+        ifProgramYearFieldExists(() => {
             cy.get('#form-element-wrapper_260').within(() => {
                 cy.get('div.required-text').should('be.visible');
             });

--- a/cypress/automated-tests/youth-pass/successful-youth-pass-submission.cy.js
+++ b/cypress/automated-tests/youth-pass/successful-youth-pass-submission.cy.js
@@ -1,5 +1,5 @@
 import { getRandomApplicantAge } from '../../common/birthdate-constants';
-import { ifExists } from '../../common/if-exists';
+import { ifProgramYearFieldExists } from '../../common/if-exists';
 
 describe('Youth Pass Successful Submission', () => {
     const faker = require('faker');
@@ -26,7 +26,7 @@ describe('Youth Pass Successful Submission', () => {
         const applicantLastName = faker.name.lastName();
 
         cy.get('#element116_Apply').click().blur();
-        ifExists('#form-element-wrapper_260', () => {
+        ifProgramYearFieldExists(() => {
             cy.get('#element260_Current').click().blur();
         });
         cy.get('#element11').type(applicantFirstName).blur();

--- a/cypress/common/if-exists.js
+++ b/cypress/common/if-exists.js
@@ -1,15 +1,25 @@
 /**
- * Executes the callback only if the element exists on the page.
+ * Executes the callback only if the program year selection element exists on the page.
  * 
- * @callback ifExistsCallback
+ * @callback ifProgramYearExistsCallback
  * 
- * @param {string} element Selector string for an element on the page.
- * @param {ifExistsCallback} callback Callback function to be executed only if the element exists.
+ * @param {ifProgramYearExistsCallback} callback Callback function to be executed only if the element exists.
 */
-export function ifExists(element, callback) {
-  cy.get('body').then((body) => {
-    if (body.find(element).length > 0) {
-        callback();
-    }
-  });
-};
+export function ifProgramYearFieldExists(callback) {
+  if (multipleProgramYears()) {
+      callback();
+  };
+
+  /** 
+   * Return true or false to determine if applicant can select multiple program years
+   * i.e., if test is running between 10/01 and 10/14
+  */
+   function multipleProgramYears() {
+      const todaysDate = new Date();
+      if (todaysDate.getMonth() + 1 == 10 && todaysDate.getDate() <= 14) {
+          return true;
+      } else {
+          return false;
+      }
+  };
+}


### PR DESCRIPTION
This PR modifies the conditional checking logic used to determine if automated tests must act on the Program Year Selection field within a Youth Pass application. This field only appears Oct 1 - 14 each year. 

The updated logic checks the current date against the range of Oct 1 - 14 and either acts upon the Program Year Selection field or skips to the next step of the test. 

Pros:
- Reduced chance that the test will be affected by factors out of our control (SimpliGov changes, slow page loads, etc.)
- Tighter scoping of conditional function increases clarity around its purpose and goal
- Function no longer has to check the entirety of the HTML body to determine if a single element exists

Cons:
-  Function is now less adaptable to other elements, if needed in the future
- Test now has a layer of date checking that may cause failures to be more challenging to debug/reproduce