### PR TITLE
Feat: Run prod automation scripts automatically on csv merge

### DIFF
--- a/.github/workflows/automation-prod.yml
+++ b/.github/workflows/automation-prod.yml
@@ -3,6 +3,11 @@ on:
   workflow_dispatch:
   schedule:
     - cron: "0 5 * * *" # run at 5 AM UTC
+  push:
+    branches:
+      - 'main'
+    paths:
+      - '**.csv'
 jobs:
   cypress-prod:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR came from an improvement idea, not an Asana task. If possible, we should try to run the production automation tests automatically every time a change to a `.csv` file is merged to the `main` branch. 

Following [these instructions](https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#running-your-workflow-only-when-a-push-to-specific-branches-occurs), I believe these changes will accomplish an automatic run of the production tests, removing the necessity to manually run the GitHub workflow every time a data source is changed.