### PR TITLE
add alert copy support for blind access and senior

### DIFF
--- a/assets/blind_html/emails/application_submitted_in_store_pickup_emails/application-submitted-in-store-pickup-chinese-simplified.html
+++ b/assets/blind_html/emails/application_submitted_in_store_pickup_emails/application-submitted-in-store-pickup-chinese-simplified.html
@@ -131,19 +131,11 @@
         <!-- Body copy -->
         <h1>申请已提交!</h1>
 
-        <p>
-          我们正在核实你是否有资格参加
-          <a href="https://www.mbta.com/fares/reduced/blind-access-charliecard">盲人乘车查理卡计划</a>。
-        </p>
+        <p>我们正在核实你是否有资格参加<a href="https://www.mbta.com/fares/reduced/blind-access-charliecard">盲人乘车查理卡计划</a>。</p>
 
-        <p>
-          MBTA 在邮寄临时和永久减价查理卡方面继续遇到延误。 这些延误是设备持续故障的结果。 很抱歉给您带来不便。 如果我们无法处理您的申请，我们会与您联系。
-        </p>
+        <p><span class="formElementOnEditor" contenteditable="false" data-row-name="element173-hiddenTitle">Generated Content: Alert text<em><small>(no title)</small></em></span></p>
 
-        <p>
-          如果你的申请获得批准，我们会通知你何时可以在
-          <a href="https://www.mbta.com/fares/charliecard-store">查理卡出售店</a>取卡。在你收到卡已准备就绪的电子邮件之前，请不要前往查理卡出售店查询。
-        </p>
+        <p>如果你的申请获得批准，我们会通知你何时可以在<a href="https://www.mbta.com/fares/charliecard-store">查理卡出售店</a>取卡。在你收到卡已准备就绪的电子邮件之前，请不要前往查理卡出售店查询。</p>
 
         <h2>有问题吗?</h2>
 
@@ -166,9 +158,7 @@
 
         <h2>告诉我们你的体验</h2>
 
-        <p>
-          参加我们的两分钟问卷调查。你的反馈意见有助于我们改进盲人乘车查理卡的申请流程。 
-        </p>
+        <p>参加我们的两分钟问卷调查。你的反馈意见有助于我们改进盲人乘车查理卡的申请流程。</p>
 
         <!-- Button -->
         <table border="0" cellspacing="0" cellpadding="0" role="presentation">

--- a/assets/blind_html/emails/application_submitted_in_store_pickup_emails/application-submitted-in-store-pickup-chinese-traditional.html
+++ b/assets/blind_html/emails/application_submitted_in_store_pickup_emails/application-submitted-in-store-pickup-chinese-traditional.html
@@ -131,17 +131,11 @@
         <!-- Body copy -->
         <h1>申請已提交！</h1>
 
-        <p>
-          我們正在核實你是否有資格參加<a href="https://www.mbta.com/fares/reduced/blind-access-charliecard">盲人乘車查理卡計劃</a>。
-        </p>
+        <p>我們正在核實你是否有資格參加<a href="https://www.mbta.com/fares/reduced/blind-access-charliecard">盲人乘車查理卡計劃</a>。</p>
 
-        <p>
-          MBTA 在郵寄臨時和永久減價查理卡方面繼續遇到延誤。 這些延誤是設備持續故障的結果。 很抱歉給您帶來不便。 如果我們無法處理您的申請，我們會與您聯繫。
-        </p>
+        <p><span class="formElementOnEditor" contenteditable="false" data-row-name="element173-hiddenTitle">Generated Content: Alert text<em><small>(no title)</small></em></span></p>
 
-        <p>
-          如果你的申請獲得批准，我們會通知你何時在<a href="https://www.mbta.com/fares/charliecard-store">查理卡出售店</a>取卡。在你收到卡已準備就緒的電子郵件之前，請不要前往查理卡出售店查詢。
-        </p>
+        <p>如果你的申請獲得批准，我們會通知你何時在<a href="https://www.mbta.com/fares/charliecard-store">查理卡出售店</a>取卡。在你收到卡已準備就緒的電子郵件之前，請不要前往查理卡出售店查詢。</p>
 
         <h2>有問題嗎?</h2>
 
@@ -164,9 +158,7 @@
         
         <h2>告訴我們你的體驗</h2>
 
-        <p>
-          參加我們的兩分鐘問卷調查。你的囘饋有助於我們改進盲人乘車查理卡的申請流程。
-        </p>
+        <p>參加我們的兩分鐘問卷調查。你的囘饋有助於我們改進盲人乘車查理卡的申請流程。</p>
 
         <!-- Button -->
         <table border="0" cellspacing="0" cellpadding="0" role="presentation">

--- a/assets/blind_html/emails/application_submitted_in_store_pickup_emails/application-submitted-in-store-pickup-english.html
+++ b/assets/blind_html/emails/application_submitted_in_store_pickup_emails/application-submitted-in-store-pickup-english.html
@@ -131,32 +131,15 @@
         <!-- Body copy -->
         <h1>Application submitted!</h1>
 
-        <p>
-          We're verifying your eligibility for the
-          <a href="https://www.mbta.com/fares/reduced/blind-access-charliecard">Blind Access CharlieCard Program</a>.
-        </p>
+        <p>We're verifying your eligibility for the <a href="https://www.mbta.com/fares/reduced/blind-access-charliecard">Blind Access CharlieCard Program</a>.</p>
 
-        <p>
-          The MBTA continues to experience delays in mailing temporary and permanent reduced fare CharlieCards. These delays
-          are a result of continued equipment malfunctions. We apologize for any inconvenience. We'll contact you if we're
-          unable to process your application.
-        </p>
+        <p><span class="formElementOnEditor" contenteditable="false" data-row-name="element173-hiddenTitle">Generated Content: Alert text<em><small>(no title)</small></em></span></p>
 
-        <p>
-          If your application is approved, we'll let you know when you can
-          pick up your card at the
-          <a href="https://www.mbta.com/fares/charliecard-store">CharlieCard Store</a>. Please do not visit the
-          CharlieCard Store until you receive an
-          email that your card is ready.
-        </p>
+        <p>If your application is approved, we'll let you know when you can pick up your card at the <a href="https://www.mbta.com/fares/charliecard-store">CharlieCard Store</a>. Please do not visit the CharlieCard Store until you receive an email that your card is ready.</p>
 
         <h2>Questions?</h2>
 
-        <p>
-          Contact
-          <a href="https://www.mbta.com/customer-support">Customer Support using their online form</a>
-          or call the number below.
-        </p>
+        <p>Contact <a href="https://www.mbta.com/customer-support">Customer Support using their online form</a> or call the number below.</p>
 
         <p>
           Monday &ndash; Friday: 6:30 AM &ndash; 8 PM<br />
@@ -172,10 +155,7 @@
 
         <h2>Tell us about your experience</h2>
 
-        <p>
-          Take our two-minute survey. Your feedback helps us improve the
-          Blind Access CharlieCard application process.
-        </p>
+        <p>Take our two-minute survey. Your feedback helps us improve the Blind Access CharlieCard application process.</p>
 
         <!-- Button -->
         <table border="0" cellspacing="0" cellpadding="0" role="presentation">
@@ -207,8 +187,7 @@
     <!-- Footer -->
     <footer>
       <p style="margin-top: 24px">
-        <a href="https://www.mbta.com/policies/privacy-policy#4.4" target="_blank" style="color: #165c96">Privacy
-          policy</a>
+        <a href="https://www.mbta.com/policies/privacy-policy#4.4" target="_blank" style="color: #165c96">Privacy policy</a>
       </p>
     </footer>
   </div>

--- a/assets/blind_html/emails/application_submitted_in_store_pickup_emails/application-submitted-in-store-pickup-portuguese.html
+++ b/assets/blind_html/emails/application_submitted_in_store_pickup_emails/application-submitted-in-store-pickup-portuguese.html
@@ -131,27 +131,15 @@
         <!-- Body copy -->
         <h1>Pedido enviado</h1>
 
-        <p>
-          Estamos verificando sua elegibilidade para o 
-          <a href="https://www.mbta.com/fares/reduced/blind-access-charliecard">Programa do Blind Access CharlieCard</a>.
-        </p>
+        <p>Estamos verificando sua elegibilidade para o <a href="https://www.mbta.com/fares/reduced/blind-access-charliecard">Programa do Blind Access CharlieCard</a>.</p>
 
-        <p>
-          A MBTA continua a sofrer atrasos no envio de CharlieCards com tarifas reduzidas temporárias e permanentes. Esses
-          atrasos são resultado de avarias contínuas do equipamento. Pedimos desculpas por qualquer inconveniente. Entraremos em
-          contato com você se não conseguirmos processar sua inscrição.
-        </p>
+        <p><span class="formElementOnEditor" contenteditable="false" data-row-name="element173-hiddenTitle">Generated Content: Alert text<em><small>(no title)</small></em></span></p>
 
-        <p>
-          Se o pedido for aprovado, informaremos quando poderá retirar o cartão na 
-          <a href="https://www.mbta.com/fares/charliecard-store">CharlieCard Store</a>. Não vá à CharlieCard Store até receber um e-mail informando que seu cartão está pronto.
-        </p>
+        <p>Se o pedido for aprovado, informaremos quando poderá retirar o cartão na <a href="https://www.mbta.com/fares/charliecard-store">CharlieCard Store</a>. Não vá à CharlieCard Store até receber um e-mail informando que seu cartão está pronto.</p>
 
         <h2>Dúvidas?</h2>
 
-        <p>
-          Contate o <a href="https://www.mbta.com/customer-support">Atendimento ao cliente usando o formulário on-line</a> ou ligue para os números abaixo.
-        </p>
+        <p>Contate o <a href="https://www.mbta.com/customer-support">Atendimento ao cliente usando o formulário on-line</a> ou ligue para os números abaixo.</p>
 
         <p>
           Segunda a sexta: Das 6h30 às 20h00<br />
@@ -166,9 +154,7 @@
 
         <h2>Conte-nos como foi sua experiência</h2>
 
-        <p>
-          Responda uma pesquisa de 2 minutos. O seu feedback nos ajuda a melhorar o processo de solicitação do Blind Access CharlieCard.
-        </p>
+        <p>Responda uma pesquisa de 2 minutos. O seu feedback nos ajuda a melhorar o processo de solicitação do Blind Access CharlieCard.</p>
 
         <!-- Button -->
         <table border="0" cellspacing="0" cellpadding="0" role="presentation">

--- a/assets/blind_html/emails/application_submitted_in_store_pickup_emails/application-submitted-in-store-pickup-spanish.html
+++ b/assets/blind_html/emails/application_submitted_in_store_pickup_emails/application-submitted-in-store-pickup-spanish.html
@@ -131,30 +131,15 @@
         <!-- Body copy -->
         <h1>¡Solicitud enviada!</h1>
 
-        <p>
-          Estamos verificando su admisibilidad para el programa de acceso para personas ciegas
-          <a href="https://www.mbta.com/fares/reduced/blind-access-charliecard">Blind Access CharlieCard</a>.
-        </p>
+        <p>Estamos verificando su admisibilidad para el programa de acceso para personas ciegas <a href="https://www.mbta.com/fares/reduced/blind-access-charliecard">Blind Access CharlieCard</a>.</p>
 
-        <p>
-          La MBTA continúa experimentando demoras en el envío de tarjetas CharlieCard temporales y permanentes con
-          tarifas reducidas. Estos retrasos son el resultado de fallas continuas en los equipos. Nos disculpamos por
-          cualquier inconveniente. Nos comunicaremos con usted si no podemos procesar su solicitud.
-        </p>
+        <p><span class="formElementOnEditor" contenteditable="false" data-row-name="element173-hiddenTitle">Generated Content: Alert text<em><small>(no title)</small></em></span></p>
 
-        <p>
-          Si su solicitud es aprobada, le haremos saber cuándo puede recoger su tarjeta en la
-          <a href="https://www.mbta.com/fares/charliecard-store">Tienda CharlieCard</a>. Por favor, no visite la Tienda
-          CharlieCard hasta que reciba un correo electrónico indicando que su tarjeta está lista.
-        </p>
+        <p>Si su solicitud es aprobada, le haremos saber cuándo puede recoger su tarjeta en la <a href="https://www.mbta.com/fares/charliecard-store">Tienda CharlieCard</a>. Por favor, no visite la Tienda CharlieCard hasta que reciba un correo electrónico indicando que su tarjeta está lista.</p>
 
         <h2>¿Preguntas?</h2>
 
-        <p>
-          Póngase en contacto con el
-          <a href="https://www.mbta.com/customer-support">Servicio de atención al cliente a través de
-            su formulario en línea</a> o llame al número que aparece a continuación.
-        </p>
+        <p>Póngase en contacto con el <a href="https://www.mbta.com/customer-support">Servicio de atención al cliente a través de su formulario en línea</a> o llame al número que aparece a continuación.</p>
 
         <p>
           Lunes &ndash; viernes: 6:30 AM &ndash; 8 PM<br />
@@ -170,10 +155,7 @@
 
         <h2>Cuéntenos su experiencia</h2>
 
-        <p>
-          Responda a nuestra encuesta de dos minutos. Sus comentarios nos ayudan a mejorar el proceso de solicitud de la
-          tarjeta CharlieCard de Blind Access.
-        </p>
+        <p>Responda a nuestra encuesta de dos minutos. Sus comentarios nos ayudan a mejorar el proceso de solicitud de la tarjeta CharlieCard de Blind Access.</p>
 
         <!-- Button -->
         <table border="0" cellspacing="0" cellpadding="0" role="presentation">
@@ -206,8 +188,7 @@
     <!-- Footer -->
     <footer>
       <p style="margin-top: 24px">
-        <a href="https://www.mbta.com/policies/privacy-policy#4.4" target="_blank" style="color: #165c96">Política de
-          privacidad</a>
+        <a href="https://www.mbta.com/policies/privacy-policy#4.4" target="_blank" style="color: #165c96">Política de privacidad</a>
       </p>
     </footer>
   </div>

--- a/assets/blind_html/emails/application_submitted_mail_emails/application-submitted-mail-chinese-simplified.html
+++ b/assets/blind_html/emails/application_submitted_mail_emails/application-submitted-mail-chinese-simplified.html
@@ -130,17 +130,11 @@
 
         <!-- Body copy -->
         <h1>申请已提交!</h1>
-        <p>
-          我们正在核实你是否有资格参加<a href="https://www.mbta.com/fares/reduced/blind-access-charliecard">盲人乘车查理卡计划</a>。
-        </p>
+        <p>我们正在核实你是否有资格参加<a href="https://www.mbta.com/fares/reduced/blind-access-charliecard">盲人乘车查理卡计划</a>。</p>
 
-        <p>
-          MBTA 在邮寄临时和永久减价查理卡方面继续遇到延误。 这些延误是设备持续故障的结果。 很抱歉给您带来不便。 如果我们无法处理您的申请，我们会与您联系。
-        </p>
+        <p><span class="formElementOnEditor" contenteditable="false" data-row-name="element173-hiddenTitle">Generated Content: Alert text<em><small>(no title)</small></em></span></p>
 
-        <p>
-          如果你的申请获得批准，我们将通过邮件寄给你盲人乘车查理卡。
-        </p>
+        <p>如果你的申请获得批准，我们将通过邮件寄给你盲人乘车查理卡。</p>
 
         <h2>有问题吗?</h2>
 
@@ -162,9 +156,8 @@
         </p>
 
         <h2>告诉我们你的体验</h2>
-        <p>
-          参加我们的两分钟问卷调查。你的反馈意见有助于我们改进盲人乘车查理卡的申请流程。
-        </p>
+        
+        <p>参加我们的两分钟问卷调查。你的反馈意见有助于我们改进盲人乘车查理卡的申请流程。</p>
 
         <!-- Button -->
         <table border="0" cellspacing="0" cellpadding="0" role="presentation">

--- a/assets/blind_html/emails/application_submitted_mail_emails/application-submitted-mail-chinese-traditional.html
+++ b/assets/blind_html/emails/application_submitted_mail_emails/application-submitted-mail-chinese-traditional.html
@@ -131,17 +131,11 @@
         <!-- Body copy -->
         <h1>申請已提交！</h1>
 
-        <p>
-          我們正在核實你是否有資格參加<a href="https://www.mbta.com/fares/reduced/blind-access-charliecard">盲人乘車查理卡計劃</a>。
-        </p>
+        <p>我們正在核實你是否有資格參加<a href="https://www.mbta.com/fares/reduced/blind-access-charliecard">盲人乘車查理卡計劃</a>。</p>
 
-        <p>
-          MBTA 在郵寄臨時和永久減價查理卡方面繼續遇到延誤。 這些延誤是設備持續故障的結果。 很抱歉給您帶來不便。 如果我們無法處理您的申請，我們會與您聯繫。
-        </p>
+        <p><span class="formElementOnEditor" contenteditable="false" data-row-name="element173-hiddenTitle">Generated Content: Alert text<em><small>(no title)</small></em></span></p>
 
-        <p>
-          如果你的申請獲得批准，我們將透過郵件寄給你盲人乘車查理卡。 
-        </p>
+        <p>如果你的申請獲得批准，我們將透過郵件寄給你盲人乘車查理卡。</p>
 
         <h2>有問題嗎?</h2>
 
@@ -164,9 +158,7 @@
 
         <h2>告訴我們你的體驗</h2>
 
-        <p>
-          參加我們的兩分鐘問卷調查。你的囘饋有助於我們改進盲人乘車查理卡的申請流程。
-        </p>
+        <p>參加我們的兩分鐘問卷調查。你的囘饋有助於我們改進盲人乘車查理卡的申請流程。</p>
 
         <!-- Button -->
         <table border="0" cellspacing="0" cellpadding="0" role="presentation">

--- a/assets/blind_html/emails/application_submitted_mail_emails/application-submitted-mail-english.html
+++ b/assets/blind_html/emails/application_submitted_mail_emails/application-submitted-mail-english.html
@@ -130,28 +130,15 @@
 
         <!-- Body copy -->
         <h1>Application submitted!</h1>
-        <p>
-          We're verifying your eligibility for the
-          <a href="https://www.mbta.com/fares/reduced/blind-access-charliecard">Blind Access CharlieCard Program</a>.
-        </p>
+        <p>We're verifying your eligibility for the <a href="https://www.mbta.com/fares/reduced/blind-access-charliecard">Blind Access CharlieCard Program</a>.</p>
 
-        <p>
-          The MBTA continues to experience delays in mailing temporary and permanent reduced fare CharlieCards. These delays
-          are a result of continued equipment malfunctions. We apologize for any inconvenience. We'll contact you if we're
-          unable to process your application.
-        </p>
+        <p><span class="formElementOnEditor" contenteditable="false" data-row-name="element173-hiddenTitle">Generated Content: Alert text<em><small>(no title)</small></em></span></p>
 
-        <p>
-          If your application is approved, you'll receive your Blind Access
-          CharlieCard in the mail.
-        </p>
+        <p>If your application is approved, we'll send you your Blind Access CharlieCard in the mail.</p>
 
         <h2>Questions?</h2>
-        <p>
-          Contact
-          <a href="https://www.mbta.com/customer-support">Customer Support using their online form</a>
-          or call the number below.
-        </p>
+        <p>Contact <a href="https://www.mbta.com/customer-support">Customer Support using their online form</a> or call the number below.</p>
+
         <p>
           Monday &ndash; Friday: 6:30 AM &ndash; 8 PM<br />
           Saturday &ndash; Sunday: 8 AM &ndash; 4 PM
@@ -164,10 +151,7 @@
         </p>
 
         <h2>Tell us about your experience</h2>
-        <p>
-          Take our two-minute survey. Your feedback helps us improve the
-          Blind Access CharlieCard application.
-        </p>
+        <p>Take our two-minute survey. Your feedback helps us improve the Blind Access CharlieCard application.</p>
 
         <!-- Button -->
         <table border="0" cellspacing="0" cellpadding="0" role="presentation">
@@ -199,8 +183,7 @@
     <!-- Footer -->
     <footer>
       <p style="margin-top: 24px">
-        <a href="https://www.mbta.com/policies/privacy-policy#4.4" target="_blank" style="color: #165c96">Privacy
-          policy</a>
+        <a href="https://www.mbta.com/policies/privacy-policy#4.4" target="_blank" style="color: #165c96">Privacy policy</a>
       </p>
     </footer>
   </div>

--- a/assets/blind_html/emails/application_submitted_mail_emails/application-submitted-mail-portuguese.html
+++ b/assets/blind_html/emails/application_submitted_mail_emails/application-submitted-mail-portuguese.html
@@ -131,26 +131,15 @@
         <!-- Body copy -->
         <h1>Pedido enviado!</h1>
 
-        <p>
-          Estamos verificando sua elegibilidade para o 
-          <a href="https://www.mbta.com/fares/reduced/blind-access-charliecard">Programa do Blind Access CharlieCard</a>.
-        </p>
+        <p>Estamos verificando sua elegibilidade para o <a href="https://www.mbta.com/fares/reduced/blind-access-charliecard">Programa do Blind Access CharlieCard</a>.</p>
 
-        <p>
-          A MBTA continua a sofrer atrasos no envio de CharlieCards com tarifas reduzidas temporárias e permanentes. Esses
-          atrasos são resultado de avarias contínuas do equipamento. Pedimos desculpas por qualquer inconveniente. Entraremos em
-          contato com você se não conseguirmos processar sua inscrição.
-        </p>
+        <p><span class="formElementOnEditor" contenteditable="false" data-row-name="element173-hiddenTitle">Generated Content: Alert text<em><small>(no title)</small></em></span></p>
 
-        <p>
-          Se o pedido for aprovado, receberá o Blind Access CharlieCard pelo correio.
-        </p>
+        <p>Se o pedido for aprovado, receberá o Blind Access CharlieCard pelo correio.</p>
 
         <h2>Dúvidas?</h2>
 
-        <p>
-          Contate o <a href="https://www.mbta.com/customer-support">Atendimento ao cliente usando o formulário on-line</a> ou ligue para os números abaixo.
-        </p>
+        <p>Contate o <a href="https://www.mbta.com/customer-support">Atendimento ao cliente usando o formulário on-line</a> ou ligue para os números abaixo.</p>
 
         <p>
           Segunda a sexta: Das 6h30 às 20h00<br />
@@ -165,9 +154,7 @@
 
         <h2>Conte-nos como foi sua experiência</h2>
 
-        <p>
-          Responda uma pesquisa de 2 minutos. O seu feedback nos ajuda a melhorar o processo de solicitação do Blind Access CharlieCard.
-        </p>
+        <p>Responda uma pesquisa de 2 minutos. O seu feedback nos ajuda a melhorar o processo de solicitação do Blind Access CharlieCard.</p>
 
         <!-- Button -->
         <table border="0" cellspacing="0" cellpadding="0" role="presentation">

--- a/assets/blind_html/emails/application_submitted_mail_emails/application-submitted-mail-spanish.html
+++ b/assets/blind_html/emails/application_submitted_mail_emails/application-submitted-mail-spanish.html
@@ -130,28 +130,15 @@
 
         <!-- Body copy -->
         <h1>¡Solicitud enviada!</h1>
-        <p>
-          Estamos verificando su admisibilidad para el programa de acceso para personas ciegas 
-          <a href="https://www.mbta.com/fares/reduced/blind-access-charliecard">Blind Access CharlieCard</a>.
-        </p>
+        <p>Estamos verificando su admisibilidad para el programa de acceso para personas ciegas <a href="https://www.mbta.com/fares/reduced/blind-access-charliecard">Blind Access CharlieCard</a>.</p>
 
-        <p>
-          La MBTA continúa experimentando demoras en el envío de tarjetas CharlieCard temporales y permanentes con
-          tarifas reducidas. Estos retrasos son el resultado de fallas continuas en los equipos. Nos disculpamos por
-          cualquier inconveniente. Nos comunicaremos con usted si no podemos procesar su solicitud.
-        </p>
+        <p><span class="formElementOnEditor" contenteditable="false" data-row-name="element173-hiddenTitle">Generated Content: Alert text<em><small>(no title)</small></em></span></p>
 
-        <p>
-          Si su solicitud es aprobada, le enviaremos su Blind Access CharlieCard por correo.
-        </p>
+        <p>Si su solicitud es aprobada, le enviaremos su Blind Access CharlieCard por correo.</p>
 
         <h2>¿Preguntas?</h2>
 
-        <p>
-          Póngase en contacto con el 
-          <a href="https://www.mbta.com/customer-support">Servicio de atención al cliente a través de 
-          su formulario en línea</a> o llame al número que aparece a continuación.
-        </p>
+        <p>Póngase en contacto con el <a href="https://www.mbta.com/customer-support">Servicio de atención al cliente a través de su formulario en línea</a> o llame al número que aparece a continuación.</p>
 
         <p>
           Lunes &ndash; viernes: 6:30 AM &ndash; 8 PM<br />
@@ -167,9 +154,7 @@
 
         <h2>Cuéntenos su experiencia</h2>
 
-        <p>
-          Responda a nuestra encuesta de dos minutos. Sus comentarios nos ayudan a mejorar el proceso de solicitud de la tarjeta CharlieCard de Blind Access.
-        </p>
+        <p>Responda a nuestra encuesta de dos minutos. Sus comentarios nos ayudan a mejorar el proceso de solicitud de la tarjeta CharlieCard de Blind Access.</p>
 
         <!-- Button -->
         <table border="0" cellspacing="0" cellpadding="0" role="presentation">

--- a/assets/blind_html/emails/resubmission_received_in_store_pickup_emails/resubmission-received-in-store-pickup-chinese-simplified.html
+++ b/assets/blind_html/emails/resubmission_received_in_store_pickup_emails/resubmission-received-in-store-pickup-chinese-simplified.html
@@ -129,23 +129,13 @@
                 <![endif]-->
 
         <!-- Body copy -->
-        <h1>
-          我们已收到你的更新申请
-        </h1>
+        <h1>我们已收到你的更新申请</h1>
 
-        <p>
-          我们正在核实你是否有资格参加
-          <a href="https://www.mbta.com/fares/reduced/blind-access-charliecard">盲人乘车查理卡计划</a>。
-        </p>
+        <p>我们正在核实你是否有资格参加<a href="https://www.mbta.com/fares/reduced/blind-access-charliecard">盲人乘车查理卡计划</a>。</p>
 
-        <p>
-          MBTA 在邮寄临时和永久减价查理卡方面继续遇到延误。 这些延误是设备持续故障的结果。 很抱歉给您带来不便。 如果我们无法处理您的申请，我们会与您联系。
-        </p>
+        <p><span class="formElementOnEditor" contenteditable="false" data-row-name="element173-hiddenTitle">Generated Content: Alert text<em><small>(no title)</small></em></span></p>
 
-        <p>
-          如果你的申请获得批准，我们会通知你何时可以在
-          <a href="https://www.mbta.com/fares/charliecard-store">查理卡出售店</a>取卡。在你收到卡已准备就绪的电子邮件之前，请不要前往查理卡出售店查询。
-        </p>
+        <p>如果你的申请获得批准，我们会通知你何时可以在<a href="https://www.mbta.com/fares/charliecard-store">查理卡出售店</a>取卡。在你收到卡已准备就绪的电子邮件之前，请不要前往查理卡出售店查询。</p>
 
         <h2>有问题吗?</h2>
 
@@ -168,9 +158,7 @@
 
         <h2>告诉我们你的体验</h2>
 
-        <p>
-          参加我们的两分钟问卷调查。你的反馈意见有助于我们改进盲人乘车查理卡的申请流程。 
-        </p>
+        <p>参加我们的两分钟问卷调查。你的反馈意见有助于我们改进盲人乘车查理卡的申请流程。</p>
 
         <!-- Button -->
         <table border="0" cellspacing="0" cellpadding="0" role="presentation">

--- a/assets/blind_html/emails/resubmission_received_in_store_pickup_emails/resubmission-received-in-store-pickup-chinese-traditional.html
+++ b/assets/blind_html/emails/resubmission_received_in_store_pickup_emails/resubmission-received-in-store-pickup-chinese-traditional.html
@@ -129,21 +129,13 @@
                 <![endif]-->
 
         <!-- Body copy -->
-        <h1>
-          我們已收到你的更新申請！
-        </h1>
+        <h1>我們已收到你的更新申請！</h1>
 
-        <p>
-          我們正在核實你是否有資格參加<a href="https://www.mbta.com/fares/reduced/blind-access-charliecard">盲人乘車查理卡計劃</a>。
-        </p>
+        <p>我們正在核實你是否有資格參加<a href="https://www.mbta.com/fares/reduced/blind-access-charliecard">盲人乘車查理卡計劃</a>。</p>
 
-        <p>
-          MBTA 在郵寄臨時和永久減價查理卡方面繼續遇到延誤。 這些延誤是設備持續故障的結果。 很抱歉給您帶來不便。 如果我們無法處理您的申請，我們會與您聯繫。
-        </p>
+        <p><span class="formElementOnEditor" contenteditable="false" data-row-name="element173-hiddenTitle">Generated Content: Alert text<em><small>(no title)</small></em></span></p>
 
-        <p>
-          如果你的申請獲得批准，我們會通知你何時在<a href="https://www.mbta.com/fares/charliecard-store">查理卡出售店</a>取卡。在你收到卡已準備就緒的電子郵件之前，請不要前往查理卡出售店查詢。
-        </p>
+        <p>如果你的申請獲得批准，我們會通知你何時在<a href="https://www.mbta.com/fares/charliecard-store">查理卡出售店</a>取卡。在你收到卡已準備就緒的電子郵件之前，請不要前往查理卡出售店查詢。</p>
 
         <h2>有問題嗎?</h2>
 
@@ -166,9 +158,7 @@
 
         <h2>告訴我們你的體驗</h2>
 
-        <p>
-          參加我們的兩分鐘問卷調查。你的囘饋有助於我們改進盲人乘車查理卡的申請流程。
-        </p>
+        <p>參加我們的兩分鐘問卷調查。你的囘饋有助於我們改進盲人乘車查理卡的申請流程。</p>
         
         <!-- Button -->
         <table border="0" cellspacing="0" cellpadding="0" role="presentation">

--- a/assets/blind_html/emails/resubmission_received_in_store_pickup_emails/resubmission-received-in-store-pickup-english.html
+++ b/assets/blind_html/emails/resubmission_received_in_store_pickup_emails/resubmission-received-in-store-pickup-english.html
@@ -129,29 +129,17 @@
                 <![endif]-->
 
         <!-- Body copy -->
-        <h1>
-          We've received your updated application!
-        </h1>
+        <h1>We've received your updated application!</h1>
 
-        <p>
-          We're verifying your eligibility for the
-          <a href="https://www.mbta.com/fares/reduced/blind-access-charliecard">Blind Access CharlieCard Program</a>.
-        </p>
+        <p>We're verifying your eligibility for the <a href="https://www.mbta.com/fares/reduced/blind-access-charliecard">Blind Access CharlieCard Program</a>.</p>
 
-        <p>
-          The MBTA continues to experience delays in mailing temporary and permanent reduced fare CharlieCards. These delays
-          are a result of continued equipment malfunctions. We apologize for any inconvenience. We'll contact you if we're
-          unable to process your application.
-        </p>
+        <p><span class="formElementOnEditor" contenteditable="false" data-row-name="element173-hiddenTitle">Generated Content: Alert text<em><small>(no title)</small></em></span></p>
         
         <p>If your application is approved, we'll let you know when you can pick up your card at the <a href="https://www.mbta.com/fares/charliecard-store">CharlieCard Store</a>. Please do not visit the CharlieCard Store until you receive an email that your card is ready.</p>
 
         <h2>Questions?</h2>
-        <p>
-          Contact
-          <a href="https://www.mbta.com/customer-support">Customer Support using their online form</a>
-          or call the number below.
-        </p>
+        <p>Contact <a href="https://www.mbta.com/customer-support">Customer Support using their online form</a> or call the number below.</p>
+
         <p>
           Monday &ndash; Friday: 6:30 AM &ndash; 8 PM<br />
           Saturday &ndash; Sunday: 8 AM &ndash; 4 PM
@@ -187,8 +175,7 @@
     <!-- Footer -->
     <footer>
       <p style="margin-top: 24px">
-        <a href="https://www.mbta.com/policies/privacy-policy#4.4" target="_blank" style="color: #165c96">Privacy
-          policy</a>
+        <a href="https://www.mbta.com/policies/privacy-policy#4.4" target="_blank" style="color: #165c96">Privacy policy</a>
       </p>
     </footer>
   </div>

--- a/assets/blind_html/emails/resubmission_received_in_store_pickup_emails/resubmission-received-in-store-pickup-portuguese.html
+++ b/assets/blind_html/emails/resubmission_received_in_store_pickup_emails/resubmission-received-in-store-pickup-portuguese.html
@@ -129,31 +129,17 @@
                 <![endif]-->
 
         <!-- Body copy -->
-        <h1>
-          Recebemos o pedido atualizado!
-        </h1>
+        <h1>Recebemos o pedido atualizado!</h1>
 
-        <p>
-          Estamos verificando sua elegibilidade para o 
-          <a href="https://www.mbta.com/fares/reduced/blind-access-charliecard">Programa do Blind Access CharlieCard</a>.
-        </p>
+        <p>Estamos verificando sua elegibilidade para o <a href="https://www.mbta.com/fares/reduced/blind-access-charliecard">Programa do Blind Access CharlieCard</a>.</p>
 
-        <p>
-          A MBTA continua a sofrer atrasos no envio de CharlieCards com tarifas reduzidas temporárias e permanentes. Esses
-          atrasos são resultado de avarias contínuas do equipamento. Pedimos desculpas por qualquer inconveniente. Entraremos em
-          contato com você se não conseguirmos processar sua inscrição.
-        </p>
+        <p><span class="formElementOnEditor" contenteditable="false" data-row-name="element173-hiddenTitle">Generated Content: Alert text<em><small>(no title)</small></em></span></p>
 
-        <p>
-          Se o pedido for aprovado, informaremos quando poderá retirar o cartão na 
-          <a href="https://www.mbta.com/fares/charliecard-store">CharlieCard Store</a>. Não vá à CharlieCard Store até receber um e-mail informando que seu cartão está pronto.
-        </p>
+        <p>Se o pedido for aprovado, informaremos quando poderá retirar o cartão na <a href="https://www.mbta.com/fares/charliecard-store">CharlieCard Store</a>. Não vá à CharlieCard Store até receber um e-mail informando que seu cartão está pronto.</p>
         
         <h2>Dúvidas?</h2>
 
-        <p>
-          Contate o <a href="https://www.mbta.com/customer-support">Atendimento ao cliente usando o formulário on-line</a> ou ligue para os números abaixo.
-        </p>
+        <p>Contate o <a href="https://www.mbta.com/customer-support">Atendimento ao cliente usando o formulário on-line</a> ou ligue para os números abaixo.</p>
 
         <p>
           Segunda a sexta: Das 6h30 às 20h00<br />
@@ -168,9 +154,7 @@
 
         <h2>Conte-nos como foi sua experiência</h2>
 
-        <p>
-          Responda uma pesquisa de 2 minutos. O seu feedback nos ajuda a melhorar o processo de solicitação do Blind Access CharlieCard.
-        </p>
+        <p>Responda uma pesquisa de 2 minutos. O seu feedback nos ajuda a melhorar o processo de solicitação do Blind Access CharlieCard.</p>
         
         <!-- Button -->
         <table border="0" cellspacing="0" cellpadding="0" role="presentation">

--- a/assets/blind_html/emails/resubmission_received_in_store_pickup_emails/resubmission-received-in-store-pickup-spanish.html
+++ b/assets/blind_html/emails/resubmission_received_in_store_pickup_emails/resubmission-received-in-store-pickup-spanish.html
@@ -129,32 +129,17 @@
                 <![endif]-->
 
         <!-- Body copy -->
-        <h1>
-          ¡Hemos recibido su solicitud actualizada!
-        </h1>
+        <h1>¡Hemos recibido su solicitud actualizada!</h1>
 
-        <p>
-          Estamos verificando su admisibilidad para el programa de acceso para personas ciegas 
-          <a href="https://www.mbta.com/fares/reduced/blind-access-charliecard">Blind Access CharlieCard</a>.
-        </p>
+        <p>Estamos verificando su admisibilidad para el programa de acceso para personas ciegas <a href="https://www.mbta.com/fares/reduced/blind-access-charliecard">Blind Access CharlieCard</a>.</p>
 
-        <p>
-          La MBTA continúa experimentando demoras en el envío de tarjetas CharlieCard temporales y permanentes con
-          tarifas reducidas. Estos retrasos son el resultado de fallas continuas en los equipos. Nos disculpamos por
-          cualquier inconveniente. Nos comunicaremos con usted si no podemos procesar su solicitud.
-        </p>
+        <p><span class="formElementOnEditor" contenteditable="false" data-row-name="element173-hiddenTitle">Generated Content: Alert text<em><small>(no title)</small></em></span></p>
 
-        <p>
-          Si su solicitud es aprobada, le haremos saber cuándo puede recoger su tarjeta en la 
-          <a href="https://www.mbta.com/fares/charliecard-store">Tienda CharlieCard</a>. Por favor, no visite la Tienda CharlieCard hasta que reciba un correo electrónico indicando que su tarjeta está lista.
-        </p>
+        <p>Si su solicitud es aprobada, le haremos saber cuándo puede recoger su tarjeta en la <a href="https://www.mbta.com/fares/charliecard-store">Tienda CharlieCard</a>. Por favor, no visite la Tienda CharlieCard hasta que reciba un correo electrónico indicando que su tarjeta está lista.</p>
+        
         <h2>¿Preguntas?</h2>
 
-        <p>
-          Póngase en contacto con el 
-          <a href="https://www.mbta.com/customer-support">Servicio de atención al cliente a través de 
-          su formulario en línea</a> o llame al número que aparece a continuación.
-        </p>
+        <p>Póngase en contacto con el <a href="https://www.mbta.com/customer-support">Servicio de atención al cliente a través de su formulario en línea</a> o llame al número que aparece a continuación.</p>
 
         <p>
           Lunes &ndash; viernes: 6:30 AM &ndash; 8 PM<br />
@@ -170,9 +155,7 @@
 
         <h2>Cuéntenos su experiencia</h2>
 
-        <p>
-          Responda a nuestra encuesta de dos minutos. Sus comentarios nos ayudan a mejorar el proceso de solicitud de la tarjeta CharlieCard de Blind Access.
-        </p>
+        <p>Responda a nuestra encuesta de dos minutos. Sus comentarios nos ayudan a mejorar el proceso de solicitud de la tarjeta CharlieCard de Blind Access.</p>
 
         <!-- Button -->
         <table border="0" cellspacing="0" cellpadding="0" role="presentation">

--- a/assets/blind_html/emails/resubmission_received_mail_emails/resubmission-received-mail-chinese-simplified.html
+++ b/assets/blind_html/emails/resubmission_received_mail_emails/resubmission-received-mail-chinese-simplified.html
@@ -129,21 +129,13 @@
                 <![endif]-->
 
         <!-- Body copy -->
-        <h1>
-          我们已收到你的更新申请
-        </h1>
+        <h1>我们已收到你的更新申请</h1>
 
-        <p>
-          我们正在核实你是否有资格参加<a href="https://www.mbta.com/fares/reduced/blind-access-charliecard">盲人乘车查理卡计划</a>。
-        </p>
+        <p>我们正在核实你是否有资格参加<a href="https://www.mbta.com/fares/reduced/blind-access-charliecard">盲人乘车查理卡计划</a>。</p>
 
-        <p>
-          MBTA 在邮寄临时和永久减价查理卡方面继续遇到延误。 这些延误是设备持续故障的结果。 很抱歉给您带来不便。 如果我们无法处理您的申请，我们会与您联系。
-        </p>
+        <p><span class="formElementOnEditor" contenteditable="false" data-row-name="element173-hiddenTitle">Generated Content: Alert text<em><small>(no title)</small></em></span></p>
 
-        <p>
-          如果你的申请获得批准，我们将通过邮件寄给你盲人乘车查理卡。
-        </p>
+        <p>如果你的申请获得批准，我们将通过邮件寄给你盲人乘车查理卡。</p>
 
         <h2>有问题吗?</h2>
 
@@ -166,9 +158,7 @@
 
         <h2>告诉我们你的体验</h2>
 
-        <p>
-          参加我们的两分钟问卷调查。你的反馈意见有助于我们改进盲人乘车查理卡的申请流程。 
-        </p>
+        <p>参加我们的两分钟问卷调查。你的反馈意见有助于我们改进盲人乘车查理卡的申请流程。</p>
 
         <!-- Button -->
         <table border="0" cellspacing="0" cellpadding="0" role="presentation">

--- a/assets/blind_html/emails/resubmission_received_mail_emails/resubmission-received-mail-chinese-traditional.html
+++ b/assets/blind_html/emails/resubmission_received_mail_emails/resubmission-received-mail-chinese-traditional.html
@@ -129,21 +129,13 @@
                 <![endif]-->
 
         <!-- Body copy -->
-        <h1>
-          我們已收到你的更新申請！
-        </h1>
+        <h1>我們已收到你的更新申請！</h1>
 
-        <p>
-          我們正在核實你是否有資格參加<a href="https://www.mbta.com/fares/reduced/blind-access-charliecard">盲人乘車查理卡計劃</a>。
-        </p>
+        <p>我們正在核實你是否有資格參加<a href="https://www.mbta.com/fares/reduced/blind-access-charliecard">盲人乘車查理卡計劃</a>。</p>
 
-        <p>
-          MBTA 在郵寄臨時和永久減價查理卡方面繼續遇到延誤。 這些延誤是設備持續故障的結果。 很抱歉給您帶來不便。 如果我們無法處理您的申請，我們會與您聯繫。
-        </p>
+        <p><span class="formElementOnEditor" contenteditable="false" data-row-name="element173-hiddenTitle">Generated Content: Alert text<em><small>(no title)</small></em></span></p>
 
-        <p>
-          如果你的申請獲得批准，我們將透過郵件寄給你盲人乘車查理卡。 
-        </p>
+        <p>如果你的申請獲得批准，我們將透過郵件寄給你盲人乘車查理卡。</p>
 
         <h2>有問題嗎?</h2>
 
@@ -166,9 +158,7 @@
 
         <h2>告訴我們你的體驗</h2>
 
-        <p>
-          參加我們的兩分鐘問卷調查。你的囘饋有助於我們改進盲人乘車查理卡的申請流程。
-        </p>
+        <p>參加我們的兩分鐘問卷調查。你的囘饋有助於我們改進盲人乘車查理卡的申請流程。</p>
         
         <!-- Button -->
         <table border="0" cellspacing="0" cellpadding="0" role="presentation">

--- a/assets/blind_html/emails/resubmission_received_mail_emails/resubmission-received-mail-english.html
+++ b/assets/blind_html/emails/resubmission_received_mail_emails/resubmission-received-mail-english.html
@@ -129,32 +129,21 @@
                 <![endif]-->
 
         <!-- Body copy -->
-        <h1>
-          We've received your updated application!
-        </h1>
-        <p>
-          We're verifying your eligibility for the
-          <a href="https://www.mbta.com/fares/reduced/blind-access-charliecard">Blind Access CharlieCard Program</a>.
-        </p>
+        <h1>We've received your updated application!</h1>
+        <p>We're verifying your eligibility for the <a href="https://www.mbta.com/fares/reduced/blind-access-charliecard">Blind Access CharlieCard Program</a>.</p>
 
-        <p>
-          The MBTA continues to experience delays in mailing temporary and permanent reduced fare CharlieCards. These delays
-          are a result of continued equipment malfunctions. We apologize for any inconvenience. We'll contact you if we're
-          unable to process your application.
-        </p>
+        <p><span class="formElementOnEditor" contenteditable="false" data-row-name="element173-hiddenTitle">Generated Content: Alert text<em><small>(no title)</small></em></span></p>
 
-        <p>If your application is approved, you will receive your Blind Access CharlieCard in the mail.</p>
+        <p>If your application is approved, we'll send you your Blind Access CharlieCard in the mail.</p>
 
         <h2>Questions?</h2>
-        <p>
-          Contact
-          <a href="https://www.mbta.com/customer-support">Customer Support using their online form</a>
-          or call the number below.
-        </p>
+        <p>Contact <a href="https://www.mbta.com/customer-support">Customer Support using their online form</a> or call the number below.</p>
+
         <p>
           Monday &ndash; Friday: 6:30 AM &ndash; 8 PM<br />
           Saturday &ndash; Sunday: 8 AM &ndash; 4 PM
         </p>
+
         <p>
           <strong>Main Hotline:</strong>
           <a href="tel:617-222-3200">617-222-3200</a><br />
@@ -171,8 +160,7 @@
             <td style="padding: 12px 18px 12px 18px;border-radius: 5px;background-color: #165c96;" align="center"
               bgcolor="#165c96">
               <a href="https://mbta.qualtrics.com/jfe/form/SV_8rkv64usE7uWrmS?source=resubmission" target="_blank"
-                style="font-size: 18px; font-family: 'Helvetica Neue', Helvetica, Arial, Verdana, sans-serif; font-weight: bold; color: #ffffff; text-decoration: none; display: inline-block;">Take
-                our survey</a>
+                style="font-size: 18px; font-family: 'Helvetica Neue', Helvetica, Arial, Verdana, sans-serif; font-weight: bold; color: #ffffff; text-decoration: none; display: inline-block;">Take our survey</a>
             </td>
           </tr>
         </table>
@@ -186,8 +174,7 @@
     <!-- Footer -->
     <footer>
       <p style="margin-top: 24px">
-        <a href="https://www.mbta.com/policies/privacy-policy#4.4" target="_blank" style="color: #165c96">Privacy
-          policy</a>
+        <a href="https://www.mbta.com/policies/privacy-policy#4.4" target="_blank" style="color: #165c96">Privacy policy</a>
       </p>
     </footer>
   </div>

--- a/assets/blind_html/emails/resubmission_received_mail_emails/resubmission-received-mail-portuguese.html
+++ b/assets/blind_html/emails/resubmission_received_mail_emails/resubmission-received-mail-portuguese.html
@@ -129,30 +129,17 @@
                 <![endif]-->
 
         <!-- Body copy -->
-        <h1>
-          Recebemos o pedido atualizado!
-        </h1>
+        <h1>Recebemos o pedido atualizado!</h1>
         
-        <p>
-          Estamos verificando sua elegibilidade para o 
-          <a href="https://www.mbta.com/fares/reduced/blind-access-charliecard">Programa do Blind Access CharlieCard</a>.
-        </p>
+        <p>Estamos verificando sua elegibilidade para o <a href="https://www.mbta.com/fares/reduced/blind-access-charliecard">Programa do Blind Access CharlieCard</a>.</p>
 
-        <p>
-          A MBTA continua a sofrer atrasos no envio de CharlieCards com tarifas reduzidas temporárias e permanentes. Esses
-          atrasos são resultado de avarias contínuas do equipamento. Pedimos desculpas por qualquer inconveniente. Entraremos em
-          contato com você se não conseguirmos processar sua inscrição.
-        </p>
+        <p><span class="formElementOnEditor" contenteditable="false" data-row-name="element173-hiddenTitle">Generated Content: Alert text<em><small>(no title)</small></em></span></p>
 
-        <p>
-          Se o pedido for aprovado, receberá o Blind Access CharlieCard pelo correio.
-        </p>
+        <p>Se o pedido for aprovado, receberá o Blind Access CharlieCard pelo correio.</p>
 
         <h2>Dúvidas?</h2>
 
-        <p>
-          Contate o <a href="https://www.mbta.com/customer-support">Atendimento ao cliente usando o formulário on-line</a> ou ligue para os números abaixo.
-        </p>
+        <p>Contate o <a href="https://www.mbta.com/customer-support">Atendimento ao cliente usando o formulário on-line</a> ou ligue para os números abaixo.</p>
 
         <p>
           Segunda a sexta: Das 6h30 às 20h00<br />
@@ -167,9 +154,7 @@
 
         <h2>Conte-nos como foi sua experiência</h2>
 
-        <p>
-          Responda uma pesquisa de 2 minutos. O seu feedback nos ajuda a melhorar o processo de solicitação do Blind Access CharlieCard.
-        </p>
+        <p>Responda uma pesquisa de 2 minutos. O seu feedback nos ajuda a melhorar o processo de solicitação do Blind Access CharlieCard.</p>
 
         <!-- Button -->
         <table border="0" cellspacing="0" cellpadding="0" role="presentation">

--- a/assets/blind_html/emails/resubmission_received_mail_emails/resubmission-received-mail-spanish.html
+++ b/assets/blind_html/emails/resubmission_received_mail_emails/resubmission-received-mail-spanish.html
@@ -129,31 +129,17 @@
                 <![endif]-->
 
         <!-- Body copy -->
-        <h1>
-          ¡Hemos recibido su solicitud actualizada!
-        </h1>
-        <p>
-          Estamos verificando su admisibilidad para el programa de acceso para personas ciegas 
-          <a href="https://www.mbta.com/fares/reduced/blind-access-charliecard">Blind Access CharlieCard</a>.
-        </p>
+        <h1>¡Hemos recibido su solicitud actualizada!</h1>
 
-        <p>
-          La MBTA continúa experimentando demoras en el envío de tarjetas CharlieCard temporales y permanentes con
-          tarifas reducidas. Estos retrasos son el resultado de fallas continuas en los equipos. Nos disculpamos por
-          cualquier inconveniente. Nos comunicaremos con usted si no podemos procesar su solicitud.
-        </p>
+        <p>Estamos verificando su admisibilidad para el programa de acceso para personas ciegas <a href="https://www.mbta.com/fares/reduced/blind-access-charliecard">Blind Access CharlieCard</a>.</p>
 
-        <p>
-          Si su solicitud es aprobada, le enviaremos su Blind Access CharlieCard por correo.
-        </p>
+        <p><span class="formElementOnEditor" contenteditable="false" data-row-name="element173-hiddenTitle">Generated Content: Alert text<em><small>(no title)</small></em></span></p>
+
+        <p>Si su solicitud es aprobada, le enviaremos su Blind Access CharlieCard por correo.</p>
 
         <h2>¿Preguntas?</h2>
 
-        <p>
-          Póngase en contacto con el 
-          <a href="https://www.mbta.com/customer-support">Servicio de atención al cliente a través de 
-          su formulario en línea</a> o llame al número que aparece a continuación.
-        </p>
+        <p>Póngase en contacto con el <a href="https://www.mbta.com/customer-support">Servicio de atención al cliente a través de su formulario en línea</a> o llame al número que aparece a continuación.</p>
 
         <p>
           Lunes &ndash; viernes: 6:30 AM &ndash; 8 PM<br />
@@ -169,9 +155,7 @@
 
         <h2>Cuéntenos su experiencia</h2>
 
-        <p>
-          Responda a nuestra encuesta de dos minutos. Sus comentarios nos ayudan a mejorar el proceso de solicitud de la tarjeta CharlieCard de Blind Access.
-        </p>
+        <p>Responda a nuestra encuesta de dos minutos. Sus comentarios nos ayudan a mejorar el proceso de solicitud de la tarjeta CharlieCard de Blind Access.</p>
 
         <!-- Button -->
         <table border="0" cellspacing="0" cellpadding="0" role="presentation">

--- a/assets/blind_html/thank_you_pages/first-submission-english.html
+++ b/assets/blind_html/thank_you_pages/first-submission-english.html
@@ -1,0 +1,24 @@
+<img alt="MBTA logo" class="mbta-logo thank-you-page" src="https://mbta.prod.simpligov.com/prod/portal/file/51d7628117ce4c0c9cb0000188390b62.png?t=1633355953036" style="width: 234px">
+
+<h1>Application Submitted</h1>
+
+<p>Thank you for applying for an MBTA Blind Access CharlieCard.</p>
+
+<p><span class="formElementOnEditor" contenteditable="false" data-row-name="element174-hiddenTitle">Generated Copy: English alert text<em><small>(no title)</small></em></span></p>
+
+<h2>Questions?</h2>
+
+<p>Contact <a href="https://www.mbta.com/customer-support">Customer Support using their online form <i class="fa fa-external-link" aria-hidden="true"></i></a> or call the number below.</p>
+
+<p>Monday &ndash; Friday: 6:30 AM &ndash; 8 PM<br />
+Saturday &ndash; Sunday: 8 AM &ndash; 4 PM</p>
+
+<p><strong>Main Hotline:</strong> <a href="tel:617-222-3200">617-222-3200</a><br />
+Toll Free: <a href="tel:800-392-6100">800-392-6100</a><br />
+TTY: <a href="tel:617-222-5146">617-222-5146</a></p>
+
+<h2>Tell us about your experience</h2>
+
+<p>Take our two-minute survey. Your feedback helps us improve the Blind Access CharlieCard application process.</p>
+
+<p><a href="https://mbta.qualtrics.com/jfe/form/SV_8rkv64usE7uWrmS?source=firstsubmission">Take our survey <i class="fa fa-external-link" aria-hidden="true"></i></a></p>

--- a/assets/blind_html/thank_you_pages/resubmission-english.html
+++ b/assets/blind_html/thank_you_pages/resubmission-english.html
@@ -1,0 +1,24 @@
+<img alt="MBTA logo" class="mbta-logo thank-you-page" src="https://mbta.prod.simpligov.com/prod/portal/file/51d7628117ce4c0c9cb0000188390b62.png?t=1633355953036" style="width: 234px">
+
+<h1>Application Updated</h1>
+
+<p>Thank you for updating your application.</p>
+
+<p><span class="formElementOnEditor" contenteditable="false" data-row-name="element174-hiddenTitle">Generated Copy: English alert text<em><small>(no title)</small></em></span></p>
+
+<h2>Questions?</h2>
+
+<p>Contact <a href="https://www.mbta.com/customer-support">Customer Support using their online form <i class="fa fa-external-link" aria-hidden="true"></i></a> or call the number below.</p>
+
+<p>Monday &ndash; Friday: 6:30 AM &ndash; 8 PM<br />
+Saturday &ndash; Sunday: 8 AM &ndash; 4 PM</p>
+
+<p><strong>Main Hotline:</strong> <a href="tel:617-222-3200">617-222-3200</a><br />
+Toll Free: <a href="tel:800-392-6100">800-392-6100</a><br />
+TTY: <a href="tel:617-222-5146">617-222-5146</a></p>
+
+<h2>Tell us about your experience</h2>
+
+<p>Take our two-minute survey. Your feedback helps us improve the Blind Access CharlieCard application process.</p>
+
+<p><a href="https://mbta.qualtrics.com/jfe/form/SV_8rkv64usE7uWrmS?source=resubmission">Take our survey <i class="fa fa-external-link" aria-hidden="true"></i></a></p>

--- a/assets/senior_html/emails/application_submitted_in_store_pickup_emails/application-submitted-in-store-pickup-chinese-simplified.html
+++ b/assets/senior_html/emails/application_submitted_in_store_pickup_emails/application-submitted-in-store-pickup-chinese-simplified.html
@@ -131,17 +131,11 @@
         <!-- Body copy -->
         <h1>申请已提交！</h1>
 
-        <p>
-          我们正在核实你是否有资格参加<a href="https://www.mbta.com/fares/reduced/senior-charliecard">老年人查理卡计划</a>。
-        </p>
+        <p>我们正在核实你是否有资格参加<a href="https://www.mbta.com/fares/reduced/senior-charliecard">老年人查理卡计划</a>。</p>
 
-        <p>
-          MBTA 在邮寄临时和永久减价查理卡方面继续遇到延误。 这些延误是设备持续故障的结果。 很抱歉给您带来不便。 如果我们无法处理您的申请，我们会与您联系。
-        </p>
+        <p><span class="formElementOnEditor" contenteditable="false" data-row-name="element178-hiddenTitle">Generated Content: Alert text<em><small>(no title)</small></em></span></p>
 
-        <p>
-          如果你的申请获得批准，我们会通知你何时可以在<a href="https://www.mbta.com/fares/charliecard-store">查理卡出售店</a>取卡。在你收到卡已准备就绪的电子邮件之前，请不要前往查理卡出售店查询。
-        </p>
+        <p>如果你的申请获得批准，我们会通知你何时可以在<a href="https://www.mbta.com/fares/charliecard-store">查理卡出售店</a>取卡。在你收到卡已准备就绪的电子邮件之前，请不要前往查理卡出售店查询。</p>
 
         <h2>有问题吗?</h2>
 
@@ -164,9 +158,7 @@
 
         <h2>告诉我们你的体验</h2>
 
-        <p>
-          参加我们的两分钟问卷调查。你的反馈意见有助于我们改进老年人查理卡的申请流程。 
-        </p>
+        <p>参加我们的两分钟问卷调查。你的反馈意见有助于我们改进老年人查理卡的申请流程。 </p>
 
         <!-- Button -->
         <table border="0" cellspacing="0" cellpadding="0" role="presentation">

--- a/assets/senior_html/emails/application_submitted_in_store_pickup_emails/application-submitted-in-store-pickup-chinese-traditional.html
+++ b/assets/senior_html/emails/application_submitted_in_store_pickup_emails/application-submitted-in-store-pickup-chinese-traditional.html
@@ -130,18 +130,11 @@
 
         <!-- Body copy -->
         <h1>申請已提交!</h1>
-        <p>
-          我們正在核實你是否有資格參加
-          <a href="https://www.mbta.com/fares/reduced/senior-charliecard">老人查理卡計劃</a>。
-        </p>
+        <p>我們正在核實你是否有資格參加<a href="https://www.mbta.com/fares/reduced/senior-charliecard">老人查理卡計劃</a>。</p>
 
-        <p>
-          MBTA 在郵寄臨時和永久減價查理卡方面繼續遇到延誤。 這些延誤是設備持續故障的結果。 很抱歉給您帶來不便。 如果我們無法處理您的申請，我們會與您聯繫。 
-        </p>
+        <p><span class="formElementOnEditor" contenteditable="false" data-row-name="element178-hiddenTitle">Generated Content: Alert text<em><small>(no title)</small></em></span></p>
         
-        <p>
-          如果你的申請獲得批准，我們會通知你何時可以在<a href="https://www.mbta.com/fares/charliecard-store">查理卡出售店</a>取卡。在你收到卡已準備就緒的電子郵件之前，請不要去查理卡出售店查詢。
-        </p>
+        <p>如果你的申請獲得批准，我們會通知你何時可以在<a href="https://www.mbta.com/fares/charliecard-store">查理卡出售店</a>取卡。在你收到卡已準備就緒的電子郵件之前，請不要去查理卡出售店查詢。</p>
 
         <h2>有問題嗎?</h2>
         <p>
@@ -160,9 +153,7 @@
         </p>
 
         <h2>告訴我們你的體驗</h2>
-        <p>
-          參加我們的兩分鐘問卷調查。你的回饋意見有助於我們改進老人查理卡的申請流程。 
-        </p>
+        <p>參加我們的兩分鐘問卷調查。你的回饋意見有助於我們改進老人查理卡的申請流程。</p>
 
         <!-- Button -->
         <table border="0" cellspacing="0" cellpadding="0" role="presentation">

--- a/assets/senior_html/emails/application_submitted_in_store_pickup_emails/application-submitted-in-store-pickup-english.html
+++ b/assets/senior_html/emails/application_submitted_in_store_pickup_emails/application-submitted-in-store-pickup-english.html
@@ -131,32 +131,15 @@
         <!-- Body copy -->
         <h1>Application submitted!</h1>
 
-        <p>
-          We're verifying your eligibility for the
-          <a href="https://www.mbta.com/fares/reduced/senior-charliecard">Senior CharlieCard Program</a>.
-        </p>
+        <p>We're verifying your eligibility for the <a href="https://www.mbta.com/fares/reduced/senior-charliecard">Senior CharlieCard Program</a>.</p>
 
-        <p>
-          The MBTA continues to experience delays in mailing temporary and permanent reduced fare CharlieCards. These
-          delays are a result of continued equipment malfunctions. We apologize for any inconvenience. We'll contact you
-          if we're unable to process your application.
-        </p>
+        <p><span class="formElementOnEditor" contenteditable="false" data-row-name="element178-hiddenTitle">Generated Content: Alert text<em><small>(no title)</small></em></span></p>
 
-        <p>
-          If your application is approved, we'll let you know when you can
-          pick up your card at the
-          <a href="https://www.mbta.com/fares/charliecard-store">CharlieCard Store</a>. Please do not visit the
-          CharlieCard Store until you receive an
-          email that your card is ready.
-        </p>
+        <p>If your application is approved, we'll let you know when you can pick up your card at the <a href="https://www.mbta.com/fares/charliecard-store">CharlieCard Store</a>. Please do not visit the CharlieCard Store until you receive an email that your card is ready.</p>
 
         <h2>Questions?</h2>
 
-        <p>
-          Contact
-          <a href="https://www.mbta.com/customer-support">Customer Support using their online form</a>
-          or call the numbers below.
-        </p>
+        <p>Contact <a href="https://www.mbta.com/customer-support">Customer Support using their online form</a> or call the numbers below.</p>
 
         <p>
           Monday &ndash; Friday: 6:30 AM &ndash; 8 PM<br />
@@ -172,10 +155,7 @@
 
         <h2>Tell us about your experience</h2>
 
-        <p>
-          Take our two-minute survey. Your feedback helps us improve the
-          Senior CharlieCard application process.
-        </p>
+        <p>Take our two-minute survey. Your feedback helps us improve the Senior CharlieCard application process.</p>
 
         <!-- Button -->
         <table border="0" cellspacing="0" cellpadding="0" role="presentation">
@@ -207,8 +187,7 @@
     <!-- Footer -->
     <footer>
       <p style="margin-top: 24px">
-        <a href="https://www.mbta.com/policies/privacy-policy#4.4" target="_blank" style="color: #165c96">Privacy
-          policy</a>
+        <a href="https://www.mbta.com/policies/privacy-policy#4.4" target="_blank" style="color: #165c96">Privacy policy</a>
       </p>
     </footer>
   </div>

--- a/assets/senior_html/emails/application_submitted_in_store_pickup_emails/application-submitted-in-store-pickup-portuguese.html
+++ b/assets/senior_html/emails/application_submitted_in_store_pickup_emails/application-submitted-in-store-pickup-portuguese.html
@@ -130,25 +130,15 @@
 
         <!-- Body copy -->
         <h1>Pedido enviado</h1>
-        <p>
-          Estamos verificando sua elegibilidade para o Programa do <a href="https://www.mbta.com/fares/reduced/senior-charliecard">Senior CharlieCard</a>.
-        </p>
+        <p>Estamos verificando sua elegibilidade para o Programa do <a href="https://www.mbta.com/fares/reduced/senior-charliecard">Senior CharlieCard</a>.</p>
 
-        <p>
-          A MBTA continua a sofrer atrasos no envio de CharlieCards com tarifas reduzidas temporárias e permanentes.
-          Esses atrasos são resultado de avarias contínuas do equipamento. Pedimos desculpas por qualquer inconveniente.
-          Entraremos em contato com você se não conseguirmos processar sua inscrição.
-        </p>
+        <p><span class="formElementOnEditor" contenteditable="false" data-row-name="element178-hiddenTitle">Generated Content: Alert text<em><small>(no title)</small></em></span></p>
         
-        <p>
-          Se sua inscrição for aprovada, informaremos quando poderá retirar o cartão na <a href="https://www.mbta.com/fares/charliecard-store">CharlieCard Store</a>. Não vá à CharlieCard Store até receber um e-mail informando que seu cartão está pronto.
-        </p>
+        <p>Se sua inscrição for aprovada, informaremos quando poderá retirar o cartão na <a href="https://www.mbta.com/fares/charliecard-store">CharlieCard Store</a>. Não vá à CharlieCard Store até receber um e-mail informando que seu cartão está pronto.</p>
 
         <h2>Dúvidas?</h2>
 
-        <p>
-          Contate <a href="https://www.mbta.com/customer-support">Atendimento ao cliente usando o formulário on-line</a> ou ligue para os números abaixo.
-        </p>
+        <p>Contate <a href="https://www.mbta.com/customer-support">Atendimento ao cliente usando o formulário on-line</a> ou ligue para os números abaixo.</p>
 
         <p>
           Segunda a Sexta: 6h30 &ndash; 20h00<br />
@@ -163,9 +153,7 @@
 
         <h2>Fale sua experiência para nós</h2>
 
-        <p>
-          Responda uma pesquisa de 2 minutos. O seu feedback ajuda-nos a melhorar o processo de inscrição ao Senior CharlieCard.
-        </p>
+        <p>Responda uma pesquisa de 2 minutos. O seu feedback ajuda-nos a melhorar o processo de inscrição ao Senior CharlieCard.</p>
 
         <!-- Button -->
         <table border="0" cellspacing="0" cellpadding="0" role="presentation">

--- a/assets/senior_html/emails/application_submitted_in_store_pickup_emails/application-submitted-in-store-pickup-spanish.html
+++ b/assets/senior_html/emails/application_submitted_in_store_pickup_emails/application-submitted-in-store-pickup-spanish.html
@@ -130,29 +130,14 @@
 
         <!-- Body copy -->
         <h1>¡Solicitud presentada!</h1>
-        <p>
-          Estamos verificando su elegibilidad para el
-          <a href="https://www.mbta.com/fares/reduced/senior-charliecard">Programa de CharlieCard para personas
-            mayores</a>.
-        </p>
+        <p>Estamos verificando su elegibilidad para el <a href="https://www.mbta.com/fares/reduced/senior-charliecard">Programa de CharlieCard para personas mayores</a>.</p>
 
-        <p>
-          La MBTA continúa experimentando demoras en el envío de tarjetas CharlieCard temporales y permanentes con
-          tarifas reducidas. Estos retrasos son el resultado de fallas continuas en los equipos. Nos disculpamos por
-          cualquier inconveniente. Nos comunicaremos con usted si no podemos procesar su solicitud.
-        </p>
+        <p><span class="formElementOnEditor" contenteditable="false" data-row-name="element178-hiddenTitle">Generated Content: Alert text<em><small>(no title)</small></em></span></p>
         
-          <p>
-          Si su solicitud es aprobada, le comunicaremos cuándo puede recoger su tarjeta en la
-          <a href="https://www.mbta.com/fares/charliecard-store">Tienda CharlieCard</a>. Por favor, no visite la Tienda
-          CharlieCard hasta que reciba un correo electrónico indicando que su tarjeta está lista.
-        </p>
+        <p>Si su solicitud es aprobada, le comunicaremos cuándo puede recoger su tarjeta en la <a href="https://www.mbta.com/fares/charliecard-store">Tienda CharlieCard</a>. Por favor, no visite la Tienda CharlieCard hasta que reciba un correo electrónico indicando que su tarjeta está lista.</p>
 
         <h2>¿Preguntas?</h2>
-        <p>
-          Póngase en contacto con <a href="https://www.mbta.com/customer-support">el servicio de atención al cliente a
-            través de su formulario en línea</a> o llame a los números que aparecen a continuación.
-        </p>
+        <p>Póngase en contacto con <a href="https://www.mbta.com/customer-support">el servicio de atención al cliente a través de su formulario en línea</a> o llame a los números que aparecen a continuación.</p>
         <p>
           Lunes &ndash; Viernes: 6:30 AM &ndash; 8 PM<br />
           Sábado &ndash; Domingo: 8 AM &ndash; 4 PM
@@ -164,10 +149,7 @@
         </p>
 
         <h2>Cuéntenos su experiencia</h2>
-        <p>
-          Responda a nuestra encuesta de dos minutos. Sus comentarios nos ayudan a mejorar el proceso de solicitud de la
-          tarjeta CharlieCard para personas mayores.
-        </p>
+        <p>Responda a nuestra encuesta de dos minutos. Sus comentarios nos ayudan a mejorar el proceso de solicitud de la tarjeta CharlieCard para personas mayores.</p>
 
         <!-- Button -->
         <table border="0" cellspacing="0" cellpadding="0" role="presentation">
@@ -199,8 +181,7 @@
     <!-- Footer -->
     <footer>
       <p style="margin-top: 24px">
-        <a href="https://www.mbta.com/policies/privacy-policy#4.4" target="_blank" style="color: #165c96">Política de
-          privacidad</a>
+        <a href="https://www.mbta.com/policies/privacy-policy#4.4" target="_blank" style="color: #165c96">Política de privacidad</a>
       </p>
     </footer>
   </div>

--- a/assets/senior_html/emails/application_submitted_mail_emails/application-submitted-mail-chinese-simplified.html
+++ b/assets/senior_html/emails/application_submitted_mail_emails/application-submitted-mail-chinese-simplified.html
@@ -130,27 +130,23 @@
 
         <!-- Body copy -->
         <h1>申请已提交！ </h1>
-        <p>
-          我们正在核实你是否有资格参加<a href="https://www.mbta.com/fares/reduced/senior-charliecard">老年人查理卡计划</a>。
-        </p>
+        <p>我们正在核实你是否有资格参加<a href="https://www.mbta.com/fares/reduced/senior-charliecard">老年人查理卡计划</a>。</p>
 
-        <p>
-          MBTA 在邮寄临时和永久减价查理卡方面继续遇到延误。 这些延误是设备持续故障的结果。 很抱歉给您带来不便。 如果我们无法处理您的申请，我们会与您联系。
-        </p>
+        <p><span class="formElementOnEditor" contenteditable="false" data-row-name="element178-hiddenTitle">Generated Content: Alert text<em><small>(no title)</small></em></span></p>
 
-        <p>
-          如果您的申请获得批准，您将收到邮寄的老年人查理卡。 
-        </p>
+        <p>如果您的申请获得批准，您将收到邮寄的老年人查理卡。</p>
 
         <h2>有问题吗?</h2>
         <p>
           请联系<a href="https://www.mbta.com/customer-support">客户支持 (使用网上表格) </a>
           或给下列号码打电话。
         </p>
+        
         <p>
           周一 &ndash; 周五: 早6:30 &ndash; 晚8点<br />
           周六 &ndash; 周日: 早8点 &ndash; 下午4点
         </p>
+
         <p>
           <strong>主热线: </strong>
           <a href="tel:617-222-3200">617-222-3200</a><br />
@@ -160,9 +156,7 @@
 
         <h2>告诉我们你的体验</h2>
 
-        <p>
-          参加我们的两分钟问卷调查。你的反馈意见有助于我们改进老年人查理卡的申请流程。 
-        </p>
+        <p>参加我们的两分钟问卷调查。你的反馈意见有助于我们改进老年人查理卡的申请流程。</p>
 
         <!-- Button -->
         <table border="0" cellspacing="0" cellpadding="0" role="presentation">

--- a/assets/senior_html/emails/application_submitted_mail_emails/application-submitted-mail-chinese-traditional.html
+++ b/assets/senior_html/emails/application_submitted_mail_emails/application-submitted-mail-chinese-traditional.html
@@ -130,18 +130,11 @@
 
         <!-- Body copy -->
         <h1>申請已提交！</h1>
-        <p>
-          我們正在核實你是否有資格參加
-          <a href="https://www.mbta.com/fares/reduced/senior-charliecard">老人查理卡計劃</a>。
-        </p>
+        <p>我們正在核實你是否有資格參加<a href="https://www.mbta.com/fares/reduced/senior-charliecard">老人查理卡計劃</a>。</p>
 
-        <p>
-          MBTA 在郵寄臨時和永久減價查理卡方面繼續遇到延誤。 這些延誤是設備持續故障的結果。 很抱歉給您帶來不便。 如果我們無法處理您的申請，我們會與您聯繫。 
-        </p>
+        <p><span class="formElementOnEditor" contenteditable="false" data-row-name="element178-hiddenTitle">Generated Content: Alert text<em><small>(no title)</small></em></span></p>
 
-        <p>
-          如果你的申請獲得批准，將用普通郵件把老人查理卡寄給你。 
-        </p>
+        <p>如果你的申請獲得批准，將用普通郵件把老人查理卡寄給你。</p>
 
         <h2>有問題嗎?</h2>
         <p>
@@ -160,9 +153,7 @@
         </p>
 
         <h2>告訴我們你的體驗</h2>
-        <p>
-          參加我們的兩分鐘問卷調查。你的回饋意見有助於我們改進老人查理卡的申請流程。 
-        </p>
+        <p>參加我們的兩分鐘問卷調查。你的回饋意見有助於我們改進老人查理卡的申請流程。</p>
 
         <!-- Button -->
         <table border="0" cellspacing="0" cellpadding="0" role="presentation">

--- a/assets/senior_html/emails/application_submitted_mail_emails/application-submitted-mail-english.html
+++ b/assets/senior_html/emails/application_submitted_mail_emails/application-submitted-mail-english.html
@@ -130,28 +130,15 @@
 
         <!-- Body copy -->
         <h1>Application submitted!</h1>
-        <p>
-          We're verifying your eligibility for the
-          <a href="https://www.mbta.com/fares/reduced/senior-charliecard">Senior CharlieCard Program</a>.
-        </p>
+        <p>We're verifying your eligibility for the <a href="https://www.mbta.com/fares/reduced/senior-charliecard">Senior CharlieCard Program</a>.</p>
 
-        <p>
-          The MBTA continues to experience delays in mailing temporary and permanent reduced fare CharlieCards. These
-          delays are a result of continued equipment malfunctions. We apologize for any inconvenience. We'll contact you
-          if we're unable to process your application.
-        </p>
+        <p><span class="formElementOnEditor" contenteditable="false" data-row-name="element178-hiddenTitle">Generated Content: Alert text<em><small>(no title)</small></em></span></p>
 
-        <p>
-          If your application is approved, you'll receive your Senior
-          CharlieCard in the mail.
-        </p>
+        <p>If your application is approved, you'll receive your Senior CharlieCard in the mail.</p>
 
         <h2>Questions?</h2>
-        <p>
-          Contact
-          <a href="https://www.mbta.com/customer-support">Customer Support using their online form</a>
-          or call the numbers below.
-        </p>
+        <p>Contact <a href="https://www.mbta.com/customer-support">Customer Support using their online form</a> or call the numbers below.</p>
+
         <p>
           Monday &ndash; Friday: 6:30 AM &ndash; 8 PM<br />
           Saturday &ndash; Sunday: 8 AM &ndash; 4 PM
@@ -164,10 +151,7 @@
         </p>
 
         <h2>Tell us about your experience</h2>
-        <p>
-          Take our two-minute survey. Your feedback helps us improve the
-          Senior CharlieCard application.
-        </p>
+        <p>Take our two-minute survey. Your feedback helps us improve the Senior CharlieCard application.</p>
 
         <!-- Button -->
         <table border="0" cellspacing="0" cellpadding="0" role="presentation">
@@ -199,8 +183,7 @@
     <!-- Footer -->
     <footer>
       <p style="margin-top: 24px">
-        <a href="https://www.mbta.com/policies/privacy-policy#4.4" target="_blank" style="color: #165c96">Privacy
-          policy</a>
+        <a href="https://www.mbta.com/policies/privacy-policy#4.4" target="_blank" style="color: #165c96">Privacy policy</a>
       </p>
     </footer>
   </div>

--- a/assets/senior_html/emails/application_submitted_mail_emails/application-submitted-mail-portuguese.html
+++ b/assets/senior_html/emails/application_submitted_mail_emails/application-submitted-mail-portuguese.html
@@ -130,24 +130,15 @@
 
         <!-- Body copy -->
         <h1>Pedido enviado</h1>
-        <p>
-          Estamos verificando sua elegibilidade para o Programa do <a href="https://www.mbta.com/fares/reduced/senior-charliecard">Senior CharlieCard</a>.
-        </p>
+        <p>Estamos verificando sua elegibilidade para o Programa do <a href="https://www.mbta.com/fares/reduced/senior-charliecard">Senior CharlieCard</a>.</p>
 
-        <p>
-          A MBTA continua a sofrer atrasos no envio de CharlieCards com tarifas reduzidas temporárias e permanentes.
-          Esses atrasos são resultado de avarias contínuas do equipamento. Pedimos desculpas por qualquer inconveniente.
-          Entraremos em contato com você se não conseguirmos processar sua inscrição.
-        </p>
+        <p><span class="formElementOnEditor" contenteditable="false" data-row-name="element178-hiddenTitle">Generated Content: Alert text<em><small>(no title)</small></em></span></p>
         
-        <p>
-          Se o pedido for aprovado, receberá o Senior CharlieCard pelo correio.
-        </p>
+        <p>Se o pedido for aprovado, receberá o Senior CharlieCard pelo correio.</p>
 
         <h2>Dúvidas?</h2>
-        <p>
-          Contate <a href="https://www.mbta.com/customer-support">Atendimento ao cliente usando o formulário on-line</a> ou ligue para os números abaixo.
-        </p>
+        <p>Contate <a href="https://www.mbta.com/customer-support">Atendimento ao cliente usando o formulário on-line</a> ou ligue para os números abaixo.</p>
+        
         <p>
           Segunda a Sexta: 6h30 &ndash; 20h00<br />
           Sábado a Domingo: 8h00 &ndash; 16h00
@@ -160,9 +151,7 @@
 
         <h2>Fale sua experiência para nós</h2>
 
-        <p>
-          Responda uma pesquisa de 2 minutos. O seu feedback ajuda-nos a melhorar o processo de inscrição ao Senior CharlieCard.
-        </p>
+        <p>Responda uma pesquisa de 2 minutos. O seu feedback ajuda-nos a melhorar o processo de inscrição ao Senior CharlieCard.</p>
 
         <!-- Button -->
         <table border="0" cellspacing="0" cellpadding="0" role="presentation">

--- a/assets/senior_html/emails/application_submitted_mail_emails/application-submitted-mail-spanish.html
+++ b/assets/senior_html/emails/application_submitted_mail_emails/application-submitted-mail-spanish.html
@@ -130,27 +130,15 @@
 
         <!-- Body copy -->
         <h1>¡Solicitud presentada!</h1>
-        <p>
-          Estamos verificando su elegibilidad para el
-          <a href="https://www.mbta.com/fares/reduced/senior-charliecard">Programa de CharlieCard para personas
-            mayores</a>.
-        </p>
+        <p>Estamos verificando su elegibilidad para el <a href="https://www.mbta.com/fares/reduced/senior-charliecard">Programa de CharlieCard para personas mayores</a>.</p>
 
-        <p>
-          La MBTA continúa experimentando demoras en el envío de tarjetas CharlieCard temporales y permanentes con
-          tarifas reducidas. Estos retrasos son el resultado de fallas continuas en los equipos. Nos disculpamos por
-          cualquier inconveniente. Nos comunicaremos con usted si no podemos procesar su solicitud.
-        </p>
+        <p><span class="formElementOnEditor" contenteditable="false" data-row-name="element178-hiddenTitle">Generated Content: Alert text<em><small>(no title)</small></em></span></p>
         
-        <p>
-          Si su solicitud es aprobada, recibirá su CharlieCard para personas mayores por correo. 
-        </p>
+        <p>Si su solicitud es aprobada, recibirá su CharlieCard para personas mayores por correo.</p>
 
         <h2>¿Preguntas?</h2>
-        <p>
-          Póngase en contacto con <a href="https://www.mbta.com/customer-support">el servicio de atención al cliente a
-            través de su formulario en línea</a> o llame a los números que aparecen a continuación.
-        </p>  
+        <p>Póngase en contacto con <a href="https://www.mbta.com/customer-support">el servicio de atención al cliente a través de su formulario en línea</a> o llame a los números que aparecen a continuación.</p>
+        
         <p>
           Lunes &ndash; Viernes: 6:30 AM &ndash; 8 PM<br />
           Sábado &ndash; Domingo: 8 AM &ndash; 4 PM
@@ -162,9 +150,7 @@
         </p>
 
         <h2>Cuéntenos su experiencia</h2>
-        <p>
-          Responda a nuestra encuesta de dos minutos. Sus comentarios nos ayudan a mejorar el proceso de solicitud de la tarjeta CharlieCard para personas mayores.
-        </p>
+        <p>Responda a nuestra encuesta de dos minutos. Sus comentarios nos ayudan a mejorar el proceso de solicitud de la tarjeta CharlieCard para personas mayores.</p>
 
         <!-- Button -->
         <table border="0" cellspacing="0" cellpadding="0" role="presentation">

--- a/assets/senior_html/emails/resubmission_received_in_store_pickup_emails/resubmission-received-in-store-pickup-chinese-simplified.html
+++ b/assets/senior_html/emails/resubmission_received_in_store_pickup_emails/resubmission-received-in-store-pickup-chinese-simplified.html
@@ -129,20 +129,12 @@
                 <![endif]-->
 
         <!-- Body copy -->
-        <h1>
-          我们已收到你的更新申请 
-        </h1>
-        <p>
-          我们正在核实你是否有资格参加<a href="https://www.mbta.com/fares/reduced/senior-charliecard">老年人查理卡计划</a>。
-        </p>
+        <h1>我们已收到你的更新申请</h1>
+        <p>我们正在核实你是否有资格参加<a href="https://www.mbta.com/fares/reduced/senior-charliecard">老年人查理卡计划</a>。</p>
 
-        <p>
-          MBTA 在邮寄临时和永久减价查理卡方面继续遇到延误。 这些延误是设备持续故障的结果。 很抱歉给您带来不便。 如果我们无法处理您的申请，我们会与您联系。
-        </p>
+        <p><span class="formElementOnEditor" contenteditable="false" data-row-name="element178-hiddenTitle">Generated Content: Alert text<em><small>(no title)</small></em></span></p>
 
-        <p>
-          如果你的申请获得批准，我们会通知你何时可以在<a href="https://www.mbta.com/fares/charliecard-store">查理卡出售店</a>取卡。在你收到卡已准备就绪的电子邮件之前，请不要前往查理卡出售店查询。
-        </p>
+        <p>如果你的申请获得批准，我们会通知你何时可以在<a href="https://www.mbta.com/fares/charliecard-store">查理卡出售店</a>取卡。在你收到卡已准备就绪的电子邮件之前，请不要前往查理卡出售店查询。</p>
         
         <h2>有问题吗?</h2>
         <p>
@@ -162,9 +154,7 @@
 
         <h2>告诉我们你的体验</h2>
 
-        <p>
-          参加我们的两分钟问卷调查。你的反馈意见有助于我们改进老年人查理卡的申请流程。 
-        </p>
+        <p>参加我们的两分钟问卷调查。你的反馈意见有助于我们改进老年人查理卡的申请流程。</p>
 
         <!-- Button -->
         <table border="0" cellspacing="0" cellpadding="0" role="presentation">

--- a/assets/senior_html/emails/resubmission_received_in_store_pickup_emails/resubmission-received-in-store-pickup-chinese-traditional.html
+++ b/assets/senior_html/emails/resubmission_received_in_store_pickup_emails/resubmission-received-in-store-pickup-chinese-traditional.html
@@ -130,18 +130,11 @@
 
         <!-- Body copy -->
         <h1>我們已收到你的更新申請</h1>
-        <p>
-          我們正在核實你是否有資格參加
-          <a href="https://www.mbta.com/fares/reduced/senior-charliecard">老人查理卡計劃</a>。
-        </p>
+        <p>我們正在核實你是否有資格參加<a href="https://www.mbta.com/fares/reduced/senior-charliecard">老人查理卡計劃</a>。</p>
 
-        <p>
-          MBTA 在郵寄臨時和永久減價查理卡方面繼續遇到延誤。 這些延誤是設備持續故障的結果。 很抱歉給您帶來不便。 如果我們無法處理您的申請，我們會與您聯繫。 
-        </p>
+        <p><span class="formElementOnEditor" contenteditable="false" data-row-name="element178-hiddenTitle">Generated Content: Alert text<em><small>(no title)</small></em></span></p>
         
-        <p>
-          如果你的申請獲得批准，我們會通知你何時可以在<a href="https://www.mbta.com/fares/charliecard-store">查理卡出售店</a>。在你收到卡已準備就緒的電子郵件之前，請不要去查理卡出售店查詢。
-        </p>
+        <p>如果你的申請獲得批准，我們會通知你何時可以在<a href="https://www.mbta.com/fares/charliecard-store">查理卡出售店</a>。在你收到卡已準備就緒的電子郵件之前，請不要去查理卡出售店查詢。</p>
 
 
         <h2>有問題嗎?</h2>
@@ -161,9 +154,7 @@
         </p>
 
         <h2>告訴我們你的體驗</h2>
-        <p>
-          參加我們的兩分鐘問卷調查。你的回饋意見有助於我們改進老人查理卡的申請流程。 
-        </p>
+        <p>參加我們的兩分鐘問卷調查。你的回饋意見有助於我們改進老人查理卡的申請流程。</p>
 
         <!-- Button -->
         <table border="0" cellspacing="0" cellpadding="0" role="presentation">

--- a/assets/senior_html/emails/resubmission_received_in_store_pickup_emails/resubmission-received-in-store-pickup-english.html
+++ b/assets/senior_html/emails/resubmission_received_in_store_pickup_emails/resubmission-received-in-store-pickup-english.html
@@ -129,28 +129,17 @@
                 <![endif]-->
 
         <!-- Body copy -->
-        <h1>
-          We've received your updated application!
-        </h1>
-        <p>
-          We're verifying your eligibility for the
-          <a href="https://www.mbta.com/fares/reduced/senior-charliecard">Senior CharlieCard Program</a>.
-        </p>
+        <h1>We've received your updated application!</h1>
+        
+        <p>We're verifying your eligibility for the <a href="https://www.mbta.com/fares/reduced/senior-charliecard">Senior CharlieCard Program</a>.</p>
 
-        <p>
-          The MBTA continues to experience delays in mailing temporary and permanent reduced fare CharlieCards. These
-          delays are a result of continued equipment malfunctions. We apologize for any inconvenience. We'll contact you
-          if we're unable to process your application.
-        </p>
+        <p><span class="formElementOnEditor" contenteditable="false" data-row-name="element178-hiddenTitle">Generated Content: Alert text<em><small>(no title)</small></em></span></p>
         
         <p>If your application is approved, we'll let you know when you can pick up your card at the <a href="https://www.mbta.com/fares/charliecard-store">CharlieCard Store</a>. Please do not visit the CharlieCard Store until you receive an email that your card is ready.</p>
 
         <h2>Questions?</h2>
-        <p>
-          Contact
-          <a href="https://www.mbta.com/customer-support">Customer Support using their online form</a>
-          or call the numbers below.
-        </p>
+        <p>Contact <a href="https://www.mbta.com/customer-support">Customer Support using their online form</a> or call the numbers below.</p>
+        
         <p>
           Monday &ndash; Friday: 6:30 AM &ndash; 8 PM<br />
           Saturday &ndash; Sunday: 8 AM &ndash; 4 PM
@@ -171,8 +160,7 @@
             <td style="padding: 12px 18px 12px 18px;border-radius: 5px;background-color: #165c96;" align="center"
               bgcolor="#165c96">
               <a href="https://mbta.qualtrics.com/jfe/form/SV_26x4haYENjzG31s?needsmoreinfo" target="_blank"
-                style="font-size: 18px; font-family: 'Helvetica Neue', Helvetica, Arial, Verdana, sans-serif; font-weight: bold; color: #ffffff; text-decoration: none; display: inline-block;">Take
-                our survey</a>
+                style="font-size: 18px; font-family: 'Helvetica Neue', Helvetica, Arial, Verdana, sans-serif; font-weight: bold; color: #ffffff; text-decoration: none; display: inline-block;">Take our survey</a>
             </td>
           </tr>
         </table>
@@ -186,8 +174,7 @@
     <!-- Footer -->
     <footer>
       <p style="margin-top: 24px">
-        <a href="https://www.mbta.com/policies/privacy-policy#4.4" target="_blank" style="color: #165c96">Privacy
-          policy</a>
+        <a href="https://www.mbta.com/policies/privacy-policy#4.4" target="_blank" style="color: #165c96">Privacy policy</a>
       </p>
     </footer>
   </div>

--- a/assets/senior_html/emails/resubmission_received_in_store_pickup_emails/resubmission-received-in-store-pickup-portuguese.html
+++ b/assets/senior_html/emails/resubmission_received_in_store_pickup_emails/resubmission-received-in-store-pickup-portuguese.html
@@ -132,20 +132,13 @@
         <h1>Recebemos o pedido atualizado!</h1>
         <p>Estamos verificando sua elegibilidade para o Programa do <a href="https://www.mbta.com/fares/reduced/senior-charliecard">Senior CharlieCard</a>.</p>
 
-        <p>
-          A MBTA continua a sofrer atrasos no envio de CharlieCards com tarifas reduzidas temporárias e permanentes.
-          Esses atrasos são resultado de avarias contínuas do equipamento. Pedimos desculpas por qualquer inconveniente.
-          Entraremos em contato com você se não conseguirmos processar sua inscrição.
-        </p>
+        <p><span class="formElementOnEditor" contenteditable="false" data-row-name="element178-hiddenTitle">Generated Content: Alert text<em><small>(no title)</small></em></span></p>
         
-        <p>
-          Se sua inscrição for aprovada, informaremos quando poderá retirar o cartão na <a href="https://www.mbta.com/fares/charliecard-store">CharlieCard Store</a>. Não vá à CharlieCard Store até receber um e-mail informando que seu cartão está pronto.
-        </p>
+        <p>Se sua inscrição for aprovada, informaremos quando poderá retirar o cartão na <a href="https://www.mbta.com/fares/charliecard-store">CharlieCard Store</a>. Não vá à CharlieCard Store até receber um e-mail informando que seu cartão está pronto.</p>
         
         <h2>Dúvidas?</h2>
-        <p>
-          Contate <a href="https://www.mbta.com/customer-support">Atendimento ao cliente usando o formulário on-line</a> ou ligue para os números abaixo.
-        </p>
+        <p>Contate <a href="https://www.mbta.com/customer-support">Atendimento ao cliente usando o formulário on-line</a> ou ligue para os números abaixo.</p>
+        
         <p>
           Segunda a Sexta: 6h30 &ndash; 20h00<br />
           Sábado a Domingo: 8h00 &ndash; 16h00

--- a/assets/senior_html/emails/resubmission_received_in_store_pickup_emails/resubmission-received-in-store-pickup-spanish.html
+++ b/assets/senior_html/emails/resubmission_received_in_store_pickup_emails/resubmission-received-in-store-pickup-spanish.html
@@ -130,28 +130,14 @@
 
         <!-- Body copy -->
         <h1>¡Hemos recibido su solicitud actualizada!</h1>
-        <p>
-          Estamos verificando su elegibilidad para el
-          <a href="https://www.mbta.com/fares/reduced/senior-charliecard">Programa de CharlieCard para personas
-            mayores</a>.
-        </p>
+        <p>Estamos verificando su elegibilidad para el <a href="https://www.mbta.com/fares/reduced/senior-charliecard">Programa de CharlieCard para personas mayores</a>.</p>
 
-        <p>
-          La MBTA continúa experimentando demoras en el envío de tarjetas CharlieCard temporales y permanentes con
-          tarifas reducidas. Estos retrasos son el resultado de fallas continuas en los equipos. Nos disculpamos por
-          cualquier inconveniente. Nos comunicaremos con usted si no podemos procesar su solicitud.
-        </p>
+        <p><span class="formElementOnEditor" contenteditable="false" data-row-name="element178-hiddenTitle">Generated Content: Alert text<em><small>(no title)</small></em></span></p>
         
-        <p>
-          Si su solicitud es aprobada, le comunicaremos cuándo puede recoger su tarjeta en la 
-          <a href="https://www.mbta.com/fares/charliecard-store">Tienda CharlieCard</a>. Por favor, no visite la Tienda CharlieCard hasta que reciba un correo electrónico indicando que su tarjeta está lista.
-        </p>
+        <p>Si su solicitud es aprobada, le comunicaremos cuándo puede recoger su tarjeta en la <a href="https://www.mbta.com/fares/charliecard-store">Tienda CharlieCard</a>. Por favor, no visite la Tienda CharlieCard hasta que reciba un correo electrónico indicando que su tarjeta está lista.</p>
 
         <h2>¿Preguntas?</h2>
-        <p>
-          Póngase en contacto con <a href="https://www.mbta.com/customer-support">el servicio de atención al cliente a
-            través de su formulario en línea</a> o llame a los números que aparecen a continuación.
-        </p>  
+        <p>Póngase en contacto con <a href="https://www.mbta.com/customer-support">el servicio de atención al cliente a través de su formulario en línea</a> o llame a los números que aparecen a continuación.</p>  
         <p>
           Lunes &ndash; Viernes: 6:30 AM &ndash; 8 PM<br />
           Sábado &ndash; Domingo: 8 AM &ndash; 4 PM
@@ -163,9 +149,7 @@
         </p>
 
         <h2>Cuéntenos su experiencia</h2>
-        <p>
-          Responda a nuestra encuesta de dos minutos. Sus comentarios nos ayudan a mejorar el proceso de solicitud de la tarjeta CharlieCard para personas mayores.
-        </p>
+        <p>Responda a nuestra encuesta de dos minutos. Sus comentarios nos ayudan a mejorar el proceso de solicitud de la tarjeta CharlieCard para personas mayores.</p>
 
         <!-- Button -->
         <table border="0" cellspacing="0" cellpadding="0" role="presentation">

--- a/assets/senior_html/emails/resubmission_received_mail_emails/resubmission-received-mail-chinese-simplified.html
+++ b/assets/senior_html/emails/resubmission_received_mail_emails/resubmission-received-mail-chinese-simplified.html
@@ -129,20 +129,12 @@
                 <![endif]-->
 
         <!-- Body copy -->
-        <h1>
-          我们已收到你的更新申请 
-        </h1>
-        <p>
-          我们正在核实你是否有资格参加<a href="https://www.mbta.com/fares/reduced/senior-charliecard">老年人查理卡计划</a>。
-        </p>
+        <h1>我们已收到你的更新申请</h1>
+        <p>我们正在核实你是否有资格参加<a href="https://www.mbta.com/fares/reduced/senior-charliecard">老年人查理卡计划</a>。</p>
 
-        <p>
-          MBTA 在邮寄临时和永久减价查理卡方面继续遇到延误。 这些延误是设备持续故障的结果。 很抱歉给您带来不便。 如果我们无法处理您的申请，我们会与您联系。
-        </p>
+        <p><span class="formElementOnEditor" contenteditable="false" data-row-name="element178-hiddenTitle">Generated Content: Alert text<em><small>(no title)</small></em></span></p>
 
-        <p>
-          如果您的申请获得批准，您将收到邮寄的老年人查理卡。 
-        </p>
+        <p>如果您的申请获得批准，您将收到邮寄的老年人查理卡。</p>
         
         <h2>有问题吗?</h2>
         <p>
@@ -162,9 +154,7 @@
 
         <h2>告诉我们你的体验</h2>
 
-        <p>
-          参加我们的两分钟问卷调查。你的反馈意见有助于我们改进老年人查理卡的申请流程。 
-        </p>
+        <p>参加我们的两分钟问卷调查。你的反馈意见有助于我们改进老年人查理卡的申请流程。</p>
 
         <!-- Button -->
         <table border="0" cellspacing="0" cellpadding="0" role="presentation">

--- a/assets/senior_html/emails/resubmission_received_mail_emails/resubmission-received-mail-chinese-traditional.html
+++ b/assets/senior_html/emails/resubmission_received_mail_emails/resubmission-received-mail-chinese-traditional.html
@@ -129,21 +129,12 @@
                 <![endif]-->
 
         <!-- Body copy -->
-        <h1>
-          我們已收到你的更新申請
-        </h1>
-        <p>
-          我們正在核實你是否有資格參加
-          <a href="https://www.mbta.com/fares/reduced/senior-charliecard">老人查理卡計劃</a>。
-        </p>
+        <h1>我們已收到你的更新申請</h1>
+        <p>我們正在核實你是否有資格參加<a href="https://www.mbta.com/fares/reduced/senior-charliecard">老人查理卡計劃</a>。</p>
 
-        <p>
-          MBTA 在郵寄臨時和永久減價查理卡方面繼續遇到延誤。 這些延誤是設備持續故障的結果。 很抱歉給您帶來不便。 如果我們無法處理您的申請，我們會與您聯繫。 
-        </p>
+        <p><span class="formElementOnEditor" contenteditable="false" data-row-name="element178-hiddenTitle">Generated Content: Alert text<em><small>(no title)</small></em></span></p>
         
-        <p>
-          如果你的申請獲得批准，將用普通郵件把老人查理卡寄給你。 
-        </p>
+        <p>如果你的申請獲得批准，將用普通郵件把老人查理卡寄給你。</p>
 
         <h2>有問題嗎?</h2>
         <p>
@@ -162,9 +153,7 @@
         </p>
 
         <h2>告訴我們你的體驗</h2>
-        <p>
-          參加我們的兩分鐘問卷調查。你的回饋意見有助於我們改進老人查理卡的申請流程。 
-        </p>
+        <p>參加我們的兩分鐘問卷調查。你的回饋意見有助於我們改進老人查理卡的申請流程。</p>
 
         <!-- Button -->
         <table border="0" cellspacing="0" cellpadding="0" role="presentation">

--- a/assets/senior_html/emails/resubmission_received_mail_emails/resubmission-received-mail-english.html
+++ b/assets/senior_html/emails/resubmission_received_mail_emails/resubmission-received-mail-english.html
@@ -129,28 +129,15 @@
                 <![endif]-->
 
         <!-- Body copy -->
-        <h1>
-          We've received your updated application!
-        </h1>
-        <p>
-          We're verifying your eligibility for the
-          <a href="https://www.mbta.com/fares/reduced/senior-charliecard">Senior CharlieCard Program</a>.
-        </p>
+        <h1>We've received your updated application!</h1>
+        <p>We're verifying your eligibility for the <a href="https://www.mbta.com/fares/reduced/senior-charliecard">Senior CharlieCard Program</a>.</p>
 
-        <p>
-          The MBTA continues to experience delays in mailing temporary and permanent reduced fare CharlieCards. These
-          delays are a result of continued equipment malfunctions. We apologize for any inconvenience. We'll contact you
-          if we're unable to process your application.
-        </p>
+        <p><span class="formElementOnEditor" contenteditable="false" data-row-name="element178-hiddenTitle">Generated Content: Alert text<em><small>(no title)</small></em></span></p>
         
         <p>If your application is approved, you will receive your Senior CharlieCard in the mail.</p>
 
         <h2>Questions?</h2>
-        <p>
-          Contact
-          <a href="https://www.mbta.com/customer-support">Customer Support using their online form</a>
-          or call the numbers below.
-        </p>
+        <p>Contact <a href="https://www.mbta.com/customer-support">Customer Support using their online form</a> or call the numbers below.</p>
         <p>
           Monday &ndash; Friday: 6:30 AM &ndash; 8 PM<br />
           Saturday &ndash; Sunday: 8 AM &ndash; 4 PM
@@ -186,8 +173,7 @@
     <!-- Footer -->
     <footer>
       <p style="margin-top: 24px">
-        <a href="https://www.mbta.com/policies/privacy-policy#4.4" target="_blank" style="color: #165c96">Privacy
-          policy</a>
+        <a href="https://www.mbta.com/policies/privacy-policy#4.4" target="_blank" style="color: #165c96">Privacy policy</a>
       </p>
     </footer>
   </div>

--- a/assets/senior_html/emails/resubmission_received_mail_emails/resubmission-received-mail-portuguese.html
+++ b/assets/senior_html/emails/resubmission_received_mail_emails/resubmission-received-mail-portuguese.html
@@ -130,24 +130,14 @@
 
         <!-- Body copy -->
         <h1>Recebemos o pedido atualizado!</h1>
-        <p>
-          Estamos verificando sua elegibilidade para o Programa do <a href="https://www.mbta.com/fares/reduced/senior-charliecard">Senior CharlieCard</a>.
-        </p>
+        <p>Estamos verificando sua elegibilidade para o Programa do <a href="https://www.mbta.com/fares/reduced/senior-charliecard">Senior CharlieCard</a>.</p>
 
-        <p>
-          A MBTA continua a sofrer atrasos no envio de CharlieCards com tarifas reduzidas temporárias e permanentes.
-          Esses atrasos são resultado de avarias contínuas do equipamento. Pedimos desculpas por qualquer inconveniente.
-          Entraremos em contato com você se não conseguirmos processar sua inscrição.
-        </p>
+        <p><span class="formElementOnEditor" contenteditable="false" data-row-name="element178-hiddenTitle">Generated Content: Alert text<em><small>(no title)</small></em></span></p>
         
-        <p>
-          Se o pedido for aprovado, receberá o Senior CharlieCard pelo correio.
-        </p>
+        <p>Se o pedido for aprovado, receberá o Senior CharlieCard pelo correio.</p>
         
         <h2>Dúvidas?</h2>
-        <p>
-          Contate <a href="https://www.mbta.com/customer-support">Atendimento ao cliente usando o formulário on-line</a> ou ligue para os números abaixo.
-        </p>
+        <p>Contate <a href="https://www.mbta.com/customer-support">Atendimento ao cliente usando o formulário on-line</a> ou ligue para os números abaixo.</p>
         <p>
           Segunda a Sexta: 6h30 &ndash; 20h00<br />
           Sábado a Domingo: 8h00 &ndash; 16h00

--- a/assets/senior_html/emails/resubmission_received_mail_emails/resubmission-received-mail-spanish.html
+++ b/assets/senior_html/emails/resubmission_received_mail_emails/resubmission-received-mail-spanish.html
@@ -129,30 +129,15 @@
                 <![endif]-->
 
         <!-- Body copy -->
-        <h1>
-          ¡Hemos recibido su solicitud actualizada!
-        </h1>
-        <p>
-          Estamos verificando su elegibilidad para el
-          <a href="https://www.mbta.com/fares/reduced/senior-charliecard">Programa de CharlieCard para personas
-            mayores</a>.
-        </p>
+        <h1>¡Hemos recibido su solicitud actualizada!</h1>
+        <p>Estamos verificando su elegibilidad para el <a href="https://www.mbta.com/fares/reduced/senior-charliecard">Programa de CharlieCard para personas mayores</a>.</p>
 
-        <p>
-          La MBTA continúa experimentando demoras en el envío de tarjetas CharlieCard temporales y permanentes con
-          tarifas reducidas. Estos retrasos son el resultado de fallas continuas en los equipos. Nos disculpamos por
-          cualquier inconveniente. Nos comunicaremos con usted si no podemos procesar su solicitud.
-        </p>
+        <p><span class="formElementOnEditor" contenteditable="false" data-row-name="element178-hiddenTitle">Generated Content: Alert text<em><small>(no title)</small></em></span></p>
         
-        <p>
-          Si su solicitud es aprobada, recibirá su CharlieCard para personas mayores por correo. 
-        </p>
+        <p>Si su solicitud es aprobada, recibirá su CharlieCard para personas mayores por correo.</p>
 
         <h2>¿Preguntas?</h2>
-        <p>
-          Póngase en contacto con <a href="https://www.mbta.com/customer-support">el servicio de atención al cliente a
-            través de su formulario en línea</a> o llame a los números que aparecen a continuación.
-        </p>  
+        <p>Póngase en contacto con <a href="https://www.mbta.com/customer-support">el servicio de atención al cliente a través de su formulario en línea</a> o llame a los números que aparecen a continuación.</p>  
         <p>
           Lunes &ndash; Viernes: 6:30 AM &ndash; 8 PM<br />
           Sábado &ndash; Domingo: 8 AM &ndash; 4 PM
@@ -172,8 +157,7 @@
             <td style="padding: 12px 18px 12px 18px;border-radius: 5px;background-color: #165c96;" align="center"
               bgcolor="#165c96">
               <a href="https://mbta.qualtrics.com/jfe/form/SV_26x4haYENjzG31s?needsmoreinfo" target="_blank"
-                style="font-size: 18px; font-family: 'Helvetica Neue', Helvetica, Arial, Verdana, sans-serif; font-weight: bold; color: #ffffff; text-decoration: none; display: inline-block;">
-                Responda a nuestra encuesta</a>
+                style="font-size: 18px; font-family: 'Helvetica Neue', Helvetica, Arial, Verdana, sans-serif; font-weight: bold; color: #ffffff; text-decoration: none; display: inline-block;">Responda a nuestra encuesta</a>
             </td>
           </tr>
         </table>

--- a/assets/senior_html/thank_you_pages/first_submission/first-submission-english.html
+++ b/assets/senior_html/thank_you_pages/first_submission/first-submission-english.html
@@ -6,7 +6,7 @@
 
 <p>Thank you for applying for an MBTA Senior CharlieCard.</p>
 
-<p>The MBTA continues to experience delays in mailing temporary and permanent reduced fare CharlieCards. These delays are a result of continued equipment malfunctions. We apologize for any inconvenience. We'll contact you if we're unable to process your application.</p>
+<p><span class="formElementOnEditor" contenteditable="false" data-row-name="element179-hiddenTitle">Generated Copy: English alert text<em><small>(no title)</small></em></span></p>
 
 <h2>Questions?</h2>
 

--- a/assets/senior_html/thank_you_pages/resubmission/resubmission-english.html
+++ b/assets/senior_html/thank_you_pages/resubmission/resubmission-english.html
@@ -6,7 +6,7 @@
 
 <p>Thank you for updating your application.</p>
 
-<p>The MBTA continues to experience delays in mailing temporary and permanent reduced fare CharlieCards. These delays are a result of continued equipment malfunctions. We apologize for any inconvenience. We'll contact you if we're unable to process your application.</p>
+<p><span class="formElementOnEditor" contenteditable="false" data-row-name="element179-hiddenTitle">Generated Copy: English alert text<em><small>(no title)</small></em></span></p>
 
 <h2>Questions?</h2>
 


### PR DESCRIPTION
Asana tickets: 
- [Update Fulfillment Timing Copy for BA](https://app.asana.com/0/1170867711449497/1203487228320044/f)
- [New Fulfillment Timing Copy for TAP](https://app.asana.com/0/1170867711449497/1203411572034468/f)

This PR adds support for changing fulfillment copy in emails and Thank You pages. Each form uses two hidden fields -- one for email copy (supports translations) and one for Thank You pages (English only). Editing both fields will apply copy changes in 22 places per form.