### PR TITLE
fix: Remove the blindness certification upload step

### DIFF
--- a/cypress/automated-tests/blind/successful-blind-submission.cy.js
+++ b/cypress/automated-tests/blind/successful-blind-submission.cy.js
@@ -121,18 +121,6 @@ describe('blind successful renewal submission - without an email address', () =>
     // Intentionally empty
   });
 
-  it("uploads a blindness certification", function() {
-    cy
-      .get('[data-field-code="MCBIDCardYesNo"]')
-      .contains('No')
-      .click();
-
-    cy
-      .get('#element35')
-      .attachFile('youth-pass-test-image.png');
-    cy.get('.k-text-success').should('exist');
-  });
-
   it("uploads a photo ID", function() {
     cy
       .get('#element25')


### PR DESCRIPTION
[Update Automated Testing Accordingly](https://app.asana.com/0/696643827122369/1203641337502703/f)

This upload field is no longer on the form.