### PR TITLE
add mobility center copy

### DIFF
--- a/assets/blind_html/emails/approved_by_mail_emails/approved-by-mail-chinese-simplified.html
+++ b/assets/blind_html/emails/approved_by_mail_emails/approved-by-mail-chinese-simplified.html
@@ -130,22 +130,13 @@
 
         <!-- Body copy -->
         <h1>你的盲人乘车查理卡正在发送过程中！ </h1>
-        <p>
-          你的盲人乘车查理卡将通过USPS在3-5个工作日内寄到你的邮寄地址。
-        </p>
+        <p>你的盲人乘车查理卡将通过USPS在3-5个工作日内寄到你的邮寄地址。</p>
 
         <h2>关于你的卡</h2>
-
         <ul>
-          <li>
-            你（和导盲犬）可以使用你的盲人乘车查理卡免费乘坐所有MBTA固定路线交通服务（公交车、地铁、通勤列车和渡轮）。 MBTA总是允许使用服务动物。
-          </li>
-          <li>
-            如果你的卡损坏、丢失或被盗，你可以使用网上申请或致打电话给客户支持617-222-3200申请补发卡。
-          </li>
-          <li>
-            <strong>你的盲人乘车查理卡的有效期是5年。</strong>
-          </li>
+          <li>你（和导盲犬）可以使用你的盲人乘车查理卡免费乘坐所有MBTA固定路线交通服务（公交车、地铁、通勤列车和渡轮）。 MBTA总是允许使用服务动物。</li>
+          <li>如果你的卡损坏、丢失或被盗，你可以使用网上申请或致打电话给客户支持617-222-3200申请补发卡。</li>
+          <li><strong><span class="formElementOnEditor" contenteditable="false" data-row-name="element205-hiddenTitle">Generated Content: Card Duration Text<em><small>(no title)</small></em></span></strong></li>
         </ul>
 
         <h2>有问题吗?</h2>
@@ -167,11 +158,11 @@
           TTY: <a href="tel:617-222-5146">617-222-5146</a>
         </p>
 
-        <h2>注册以接收有关MBTA无障碍性的电子邮件</h2>
+        <h2>你是否想了解更多有关T的信息？</h2>
+        <p>我们的移动中心（<a href="https://www.mbta.com/accessibility/mbta-mobility-center">Mobility Center</a>）交通培训员随时准备为你提供帮助。要了解如何安全、独立地乘坐T、计划出行、使用移动应用程序以及获得其他交通服务，请联系<a href="tel:617-337-2756">617-337-2756</a>或<a href="mailto:howtotravel@mbta.com">howtotravel@mbta.com</a>。</p>  
 
-        <p>
-          加入MBTA的系统范围内无障碍性部门的电子邮件名单，以获取有关我们正在开展的工作的定期更新以及即将举行的会议通知。
-        </p>
+        <h2>注册以接收有关MBTA无障碍性的电子邮件</h2>
+        <p>加入MBTA的系统范围内无障碍性部门的电子邮件名单，以获取有关我们正在开展的工作的定期更新以及即将举行的会议通知。</p>
 
         <!-- Button -->
         <table border="0" cellspacing="0" cellpadding="0" role="presentation">

--- a/assets/blind_html/emails/approved_by_mail_emails/approved-by-mail-chinese-traditional.html
+++ b/assets/blind_html/emails/approved_by_mail_emails/approved-by-mail-chinese-traditional.html
@@ -130,23 +130,13 @@
 
         <!-- Body copy -->
         <h1>你的盲人乘車查理卡正在發送過程中！</h1>
-        
-        <p>
-          你的盲人乘車查理卡將透過USPS在3-5個工作日內寄到你的郵寄地址。
-        </p>
+        <p>你的盲人乘車查理卡將透過USPS在3-5個工作日內寄到你的郵寄地址。</p>
 
         <h2>關於你的卡</h2>
-
         <ul>
-          <li>
-            你（和導盲犬）可以使用你的盲人乘車查理卡免費乘坐所有MBTA固定路線交通服務（巴士、地鐵、通勤列車和渡輪）。MBTA總是允許使用服務動物。 
-          </li>
-          <li>
-            如果你的卡損壞、丟失或被盜，你可以使用線上申請或致打電話給客戶服務617-222-3200申請補發卡。
-          </li>
-          <li>
-            <strong>你的盲人乘車查理卡的有效期是5年。</strong>
-          </li>
+          <li>你（和導盲犬）可以使用你的盲人乘車查理卡免費乘坐所有MBTA固定路線交通服務（巴士、地鐵、通勤列車和渡輪）。MBTA總是允許使用服務動物。</li>
+          <li>如果你的卡損壞、丟失或被盜，你可以使用線上申請或致打電話給客戶服務617-222-3200申請補發卡。</li>
+          <li><strong><span class="formElementOnEditor" contenteditable="false" data-row-name="element205-hiddenTitle">Generated Content: Card Duration Text<em><small>(no title)</small></em></span></strong></li>
         </ul>
 
         <h2>有問題嗎?</h2>
@@ -168,11 +158,11 @@
           TTY: <a href="tel:617-222-5146">617-222-5146</a>
         </p>
 
-        <h2>註冊以接收有關MBTA無障礙性的電子郵件</h2>
+        <h2>你是否想瞭解更多有關T的資訊？</h2>
+        <p>我們的移動中心（<a href="https://www.mbta.com/accessibility/mbta-mobility-center">Mobility Center</a>）交通訓練師隨時準備為你提供幫助。要瞭解如何安全、獨立乘坐T、計劃出行、使用移動應用程式以及獲得其他交通服務，請聯絡<a href="tel:617-337-2756">617-337-2756</a>或<a href="mailto:howtotravel@mbta.com">howtotravel@mbta.com</a>。</p>
 
-        <p>
-          加入MBTA的系統範圍內無障礙性部門的電子郵件名單，以獲取有關我們正在開展的工作的定期更新以及即將舉行的會議通知。
-        </p>
+        <h2>註冊以接收有關MBTA無障礙性的電子郵件</h2>
+        <p>加入MBTA的系統範圍內無障礙性部門的電子郵件名單，以獲取有關我們正在開展的工作的定期更新以及即將舉行的會議通知。</p>
 
         <!-- Button -->
         <table border="0" cellspacing="0" cellpadding="0" role="presentation">

--- a/assets/blind_html/emails/approved_by_mail_emails/approved-by-mail-english.html
+++ b/assets/blind_html/emails/approved_by_mail_emails/approved-by-mail-english.html
@@ -130,25 +130,13 @@
 
         <!-- Body copy -->
         <h1>Your Blind Access CharlieCard is on its way!</h1>
-        <p>
-          Your Blind Access CharlieCard will arrive via USPS in 3-5 business days to
-          your mailing address.
-        </p>
+        <p>Your Blind Access CharlieCard will arrive via USPS in 3-5 business days to your mailing address.</p>
 
         <h2>About your card</h2>
-
         <ul>
-          <li>
-            You (and a sighted guide) can use your Blind Access CharlieCard for free on all MBTA fixed-route services (bus, subway, Commuter Rail, and  ferry). Service animals are always allowed on the MBTA. 
-          </li>
-          <li>
-            If your card is damaged, lost, or stolen, you can request a
-            replacement card using the online application or by calling
-            Customer Support at 617-222-3200.
-          </li>
-          <li>
-            <strong>Your Blind Access CharlieCard is valid for 5 years.</strong>
-          </li>
+          <li>You (and a sighted guide) can use your Blind Access CharlieCard for free on all MBTA fixed-route services (bus, subway, Commuter Rail, and  ferry). Service animals are always allowed on the MBTA.</li>
+          <li>If your card is damaged, lost, or stolen, you can request a replacement card using the online application or by calling Customer Support at 617-222-3200.</li>
+          <li><strong><span class="formElementOnEditor" contenteditable="false" data-row-name="element205-hiddenTitle">Generated Content: Card Duration Text<em><small>(no title)</small></em></span></strong></li>
         </ul>
 
         <h2>Questions?</h2>
@@ -162,19 +150,16 @@
           Saturday &ndash; Sunday: 8 AM &ndash; 4 PM
         </p>
         <p>
-          <strong>Main Hotline:</strong>
-          <a href="tel:617-222-3200">617-222-3200</a><br />
+          <strong>Main Hotline:</strong> <a href="tel:617-222-3200">617-222-3200</a><br />
           Toll Free: <a href="tel:800-392-6100">800-392-6100</a><br />
           TTY: <a href="tel:617-222-5146">617-222-5146</a>
         </p>
 
-        <h2>Sign up to receive MBTA accessibility emails</h2>
+        <h2>Do you want to learn more about the T?</h2>
+        <p>Our Travel Trainers at the <a href="https://www.mbta.com/accessibility/mbta-mobility-center">Mobility Center</a> are ready to assist. To learn how to ride the T safely and independently, plan your trip, use your mobile apps, and access other transit services, contact <a href="tel:617-337-2756">617-337-2756</a> or <a href="mailto:howtotravel@mbta.com">howtotravel@mbta.com</a>.</p>  
 
-        <p>
-          Join the MBTA's Department of System-wide Accessibility email list
-          to get periodic updates on the work we're doing and alerts for
-          upcoming meetings.
-        </p>
+        <h2>Sign up to receive MBTA accessibility emails</h2>
+        <p>Join the MBTA's Department of System-wide Accessibility email list to get periodic updates on the work we're doing and alerts for upcoming meetings.</p>  
 
         <!-- Button -->
         <table border="0" cellspacing="0" cellpadding="0" role="presentation">

--- a/assets/blind_html/emails/approved_by_mail_emails/approved-by-mail-portuguese.html
+++ b/assets/blind_html/emails/approved_by_mail_emails/approved-by-mail-portuguese.html
@@ -130,22 +130,13 @@
 
         <!-- Body copy -->
         <h1>O Blind Access CharlieCard está a caminho</h1>
-        <p>
-          O cartão Blind Access CharlieCard chegará pelo correio dentro de 3 a 5 dias úteis no endereço fornecido.
-        </p>
+        <p>O cartão Blind Access CharlieCard chegará pelo correio dentro de 3 a 5 dias úteis no endereço fornecido.</p>
 
         <h2>Sobre o cartão</h2>
-
         <ul>
-          <li>
-            Você (e um guia visual) podem usar o cartão Blind Access CharlieCard gratuitamente em todos os serviços de linhas fixas da MBTA (ônibus, metrô, trem e balsa). Animais de serviço são sempre permitidos na MBTA.
-          </li>
-          <li>
-            Se o cartão ficar danificado, for perdido ou roubado, solicite um outro cartão pelo modo online ou ligando para o Atendimento ao cliente no número 617-222-3200.
-          </li>
-          <li>
-            <strong>O Blind Access CharlieCard tem validade de 5 anos.</strong>
-          </li>
+          <li>Você (e um guia visual) podem usar o cartão Blind Access CharlieCard gratuitamente em todos os serviços de linhas fixas da MBTA (ônibus, metrô, trem e balsa). Animais de serviço são sempre permitidos na MBTA.</li>
+          <li>Se o cartão ficar danificado, for perdido ou roubado, solicite um outro cartão pelo modo online ou ligando para o Atendimento ao cliente no número 617-222-3200.</li>
+          <li><strong><span class="formElementOnEditor" contenteditable="false" data-row-name="element205-hiddenTitle">Generated Content: Card Duration Text<em><small>(no title)</small></em></span></strong></li>
         </ul>
 
         <h2>Dúvidas?</h2>
@@ -165,11 +156,11 @@
           TTY: <a href="tel:617-222-5146">617-222-5146</a>
         </p>
 
-        <h2>Inscreva-se para receber e-mails de acessibilidade da MBTA</h2>
+        <h2>Gostaria de saber mais sobre o T?</h2>
+        <p>Nossos Travel Trainers (orientadores de viagens) no <a href="https://www.mbta.com/accessibility/mbta-mobility-center">Mobility Center</a> (Centro de Mobilidade) estão prontos para ajudar. Para saber como usar o T de forma segura e independente, planejar a sua viagem, usar os seus aplicativos móveis e ter acesso a outros serviços de trânsito, entre em contato pelo telefone <a href="tel:617-337-2756">617-337-2756</a> ou pelo e-mail <a href="mailto:howtotravel@mbta.com">howtotravel@mbta.com</a>.</p>
 
-        <p>
-          Faça parte da lista de e-mails do Departamento de Acessibilidade da MBTA para obter atualizações periódicas sobre o trabalho que estamos realizando e alertas para as próximas reuniões.
-        </p>
+        <h2>Inscreva-se para receber e-mails de acessibilidade da MBTA</h2>
+        <p>Faça parte da lista de e-mails do Departamento de Acessibilidade da MBTA para obter atualizações periódicas sobre o trabalho que estamos realizando e alertas para as próximas reuniões.</p>  
 
         <!-- Button -->
         <table border="0" cellspacing="0" cellpadding="0" role="presentation">

--- a/assets/blind_html/emails/approved_by_mail_emails/approved-by-mail-spanish.html
+++ b/assets/blind_html/emails/approved_by_mail_emails/approved-by-mail-spanish.html
@@ -130,23 +130,13 @@
 
         <!-- Body copy -->
         <h1>¡Su Blind Access CharlieCard está en camino!</h1>
-        
-        <p>
-          Su Blind Access CharlieCard llegará por USPS en 3-5 días laborables a su dirección postal.
-        </p>
+        <p>Su Blind Access CharlieCard llegará por USPS en 3-5 días laborables a su dirección postal.</p>
 
         <h2>Acerca de su tarjeta</h2>
-
         <ul>
-          <li>
-            Usted (y un guía vidente) pueden utilizar su CharlieCard de acceso para ciegos de forma gratuita en todos los servicios de rutas fijas de la MBTA (autobús, metro, tren suburbano y ferry). Los animales de servicio están siempre permitidos en la MBTA.
-          </li>
-          <li>
-            Si su tarjeta se estropea, se pierde o se la roban, puede solicitar una tarjeta de reemplazo mediante la solicitud en línea o llamando al servicio de atención al cliente al 617-222-3200.
-          </li>
-          <li>
-            <strong>Su tarjeta Blind Access CharlieCard tiene una validez de 5 años.</strong>
-          </li>
+          <li>Usted (y un guía vidente) pueden utilizar su CharlieCard de acceso para ciegos de forma gratuita en todos los servicios de rutas fijas de la MBTA (autobús, metro, tren suburbano y ferry). Los animales de servicio están siempre permitidos en la MBTA.</li>
+          <li>Si su tarjeta se estropea, se pierde o se la roban, puede solicitar una tarjeta de reemplazo mediante la solicitud en línea o llamando al servicio de atención al cliente al 617-222-3200.</li>
+          <li><strong><span class="formElementOnEditor" contenteditable="false" data-row-name="element205-hiddenTitle">Generated Content: Card Duration Text<em><small>(no title)</small></em></span></strong></li>
         </ul>
 
         <h2>¿Preguntas?</h2>
@@ -169,12 +159,11 @@
           Teletipo TTY: <a href="tel:617-222-5146">617-222-5146</a>
         </p>
 
-        <h2>Inscríbase para recibir correos electrónicos sobre la accesibilidad de la MBTA</h2>
+        <h2>¿Quiere saber más sobre la T?</h2>
+        <p>Nuestros entrenadores de viaje en el <a href="https://www.mbta.com/accessibility/mbta-mobility-center">Mobility Center</a> (Centro de Movilidad) están dispuestos a ayudarle. Para saber cómo viajar en la T de forma segura e independiente, planificar su viaje, utilizar las aplicaciones móviles y acceder a otros servicios de tránsito, póngase en contacto con el <a href="tel:617-337-2756">617-337-2756</a> o escriba a <a href="mailto:howtotravel@mbta.com">howtotravel@mbta.com</a>.</p>
 
-        <p>
-          Suscríbase a la lista de correo electrónico del Departamento de Accesibilidad del Sistema de la MBTA para recibir
-          actualizaciones periódicas sobre el trabajo que estamos realizando y alertas sobre las próximas reuniones.
-        </p>
+        <h2>Inscríbase para recibir correos electrónicos sobre la accesibilidad de la MBTA</h2>
+        <p>Únase a la lista de correo electrónico del Departamento de Accesibilidad del Sistema de la MBTA para recibir actualizaciones periódicas sobre el trabajo que estamos realizando y alertas sobre las próximas reuniones.</p>
 
         <!-- Button -->
         <table border="0" cellspacing="0" cellpadding="0" role="presentation">

--- a/assets/blind_html/emails/approved_in_store_emails/approved-in-store-chinese-simplified.html
+++ b/assets/blind_html/emails/approved_in_store_emails/approved-in-store-chinese-simplified.html
@@ -130,22 +130,19 @@
 
         <!-- Body copy -->
         <h1>你的盲人乘车查理卡已准备好！</h1>
-        <p>
-          前往位于Downtown Crossing车站红线和橙线之间地下大厅内的查理卡出售店：7 Chauncy Street, Boston, MA 02111。
-        </p>
-
-        <p>
-          如要从车站外进入查理卡出售店，请使用101 Arch Street大楼内的无障碍电梯。
-        </p>
-
-        <p>
-          <a href="https://www.mbta.com/fares/charliecard-store">查看查理卡出售店营业时间</a>
-        </p>
-
+        <p>前往位于Downtown Crossing车站红线和橙线之间地下大厅内的查理卡出售店：7 Chauncy Street, Boston, MA 02111。</p>
+        <p>如要从车站外进入查理卡出售店，请使用101 Arch Street大楼内的无障碍电梯。</p>
+        <p><a href="https://www.mbta.com/fares/charliecard-store">查看查理卡出售店营业时间</a></p>
         <p>领取你的卡不需要预约。</p>
 
-        <h2>有问题吗?</h2>
+        <h2>关于你的卡</h2>
+        <ul>
+          <li>你（和导盲犬）可以使用你的盲人乘车查理卡免费乘坐所有MBTA固定路线交通服务（公交车、地铁、通勤列车和渡轮）。 MBTA总是允许使用服务动物。</li>
+          <li>如果你的卡损坏、丢失或被盗，你可以使用网上申请或致打电话给客户支持617-222-3200申请补发卡。</li>
+          <li><strong><span class="formElementOnEditor" contenteditable="false" data-row-name="element205-hiddenTitle">Generated Content: Card Duration Text<em><small>(no title)</small></em></span></strong></li>
+        </ul>
 
+        <h2>有问题吗?</h2>
         <p>
           请联系<a href="https://www.mbta.com/customer-support">客户支持 (使用网上表格) </a>
           或给下列号码打电话。
@@ -157,16 +154,16 @@
         </p>
 
         <p>
-          <strong>主热线: </strong>
-          <a href="tel:617-222-3200">617-222-3200</a><br />
+          <strong>主热线: </strong><a href="tel:617-222-3200">617-222-3200</a><br />
           免费电话: <a href="tel:800-392-6100">800-392-6100</a><br />
           TTY: <a href="tel:617-222-5146">617-222-5146</a>
         </p>
 
+        <h2>你是否想了解更多有关T的信息？</h2>
+        <p>我们的移动中心（<a href="https://www.mbta.com/accessibility/mbta-mobility-center">Mobility Center</a>）交通培训员随时准备为你提供帮助。要了解如何安全、独立地乘坐T、计划出行、使用移动应用程序以及获得其他交通服务，请联系<a href="tel:617-337-2756">617-337-2756</a>或<a href="mailto:howtotravel@mbta.com">howtotravel@mbta.com</a>。</p>
+
         <h2>注册以接收有关MBTA无障碍性的电子邮件</h2>
-        <p>
-          加入MBTA的系统范围内无障碍性部门的电子邮件名单，以获取有关我们正在开展的工作的定期更新以及即将举行的会议通知。
-        </p>
+        <p>加入MBTA的系统范围内无障碍性部门的电子邮件名单，以获取有关我们正在开展的工作的定期更新以及即将举行的会议通知。</p>
 
         <!-- Button -->
         <table border="0" cellspacing="0" cellpadding="0" role="presentation">

--- a/assets/blind_html/emails/approved_in_store_emails/approved-in-store-chinese-traditional.html
+++ b/assets/blind_html/emails/approved_in_store_emails/approved-in-store-chinese-traditional.html
@@ -130,20 +130,17 @@
 
         <!-- Body copy -->
         <h1>你的盲人乘車查理卡已準備好！</h1>
-        
-        <p>
-          前往位於Downtown Crossing車站紅線和橙線之間地下大廳內的查理卡出售店：7 Chauncy Street, Boston, MA 02111。
-        </p>
-
-        <p>
-          如要從車站外進入查理卡出售店，請使用101 Arch Street大樓內的無障礙電梯。
-        </p>
-
-        <p>
-          <a href="https://www.mbta.com/fares/charliecard-store">查看查理卡出售店營業時間</a>
-        </p>
-
+        <p>前往位於Downtown Crossing車站紅線和橙線之間地下大廳內的查理卡出售店：7 Chauncy Street, Boston, MA 02111。</p>
+        <p>如要從車站外進入查理卡出售店，請使用101 Arch Street大樓內的無障礙電梯。</p>
+        <p><a href="https://www.mbta.com/fares/charliecard-store">查看查理卡出售店營業時間</a></p>
         <p>領取你的卡不需要預約。</p>
+
+        <h2>關於你的卡</h2>
+        <ul>
+          <li>你（和導盲犬）可以使用你的盲人乘車查理卡免費乘坐所有MBTA固定路線交通服務（巴士、地鐵、通勤列車和渡輪）。MBTA總是允許使用服務動物。</li>
+          <li>如果你的卡損壞、丟失或被盜，你可以使用線上申請或致打電話給客戶服務617-222-3200申請補發卡。</li>
+          <li><strong><span class="formElementOnEditor" contenteditable="false" data-row-name="element205-hiddenTitle">Generated Content: Card Duration Text<em><small>(no title)</small></em></span></strong></li>
+        </ul>
 
         <h2>有問題嗎?</h2>
 
@@ -164,11 +161,11 @@
           TTY: <a href="tel:617-222-5146">617-222-5146</a>
         </p>
 
-        <h2>註冊以接收有關MBTA無障礙性的電子郵件</h2>
+        <h2>你是否想瞭解更多有關T的資訊？</h2>
+        <p>我們的移動中心（<a href="https://www.mbta.com/accessibility/mbta-mobility-center">Mobility Center</a>）交通訓練師隨時準備為你提供幫助。要瞭解如何安全、獨立乘坐T、計劃出行、使用移動應用程式以及獲得其他交通服務，請聯絡<a href="tel:617-337-2756">617-337-2756</a>或<a href="mailto:howtotravel@mbta.com">howtotravel@mbta.com</a>。</p>
 
-        <p>
-          加入MBTA的系統範圍內無障礙性部門的電子郵件名單，以獲取有關我們正在開展的工作的定期更新以及即將舉行的會議通知。
-        </p>
+        <h2>註冊以接收有關MBTA無障礙性的電子郵件</h2>
+        <p>加入MBTA的系統範圍內無障礙性部門的電子郵件名單，以獲取有關我們正在開展的工作的定期更新以及即將舉行的會議通知。</p>
 
         <!-- Button -->
         <table border="0" cellspacing="0" cellpadding="0" role="presentation">

--- a/assets/blind_html/emails/approved_in_store_emails/approved-in-store-english.html
+++ b/assets/blind_html/emails/approved_in_store_emails/approved-in-store-english.html
@@ -147,6 +147,13 @@
 
         <p>No appointment is needed to pick up your card.</p>
 
+        <h2>About your card</h2>
+        <ul>
+          <li>You (and a sighted guide) can use your Blind Access CharlieCard for free on all MBTA fixed-route services (bus, subway, Commuter Rail, and  ferry). Service animals are always allowed on the MBTA.</li>
+          <li>If your card is damaged, lost, or stolen, you can request a replacement card using the online application or by calling Customer Support at 617-222-3200.</li>
+          <li><strong><span class="formElementOnEditor" contenteditable="false" data-row-name="element205-hiddenTitle">Generated Content: Card Duration Text<em><small>(no title)</small></em></span></strong></li>
+        </ul>
+
         <h2>Questions?</h2>
         <p>
           Contact
@@ -158,18 +165,16 @@
           Saturday &ndash; Sunday: 8 AM &ndash; 4 PM
         </p>
         <p>
-          <strong>Main Hotline:</strong>
-          <a href="tel:617-222-3200">617-222-3200</a><br />
+          <strong>Main Hotline:</strong> <a href="tel:617-222-3200">617-222-3200</a><br />
           Toll Free: <a href="tel:800-392-6100">800-392-6100</a><br />
           TTY: <a href="tel:617-222-5146">617-222-5146</a>
         </p>
 
+        <h2>Do you want to learn more about the T?</h2>
+        <p>Our Travel Trainers at the <a href="https://www.mbta.com/accessibility/mbta-mobility-center">Mobility Center</a> are ready to assist. To learn how to ride the T safely and independently, plan your trip, use your mobile apps, and access other transit services, contact <a href="tel:617-337-2756">617-337-2756</a> or <a href="mailto:howtotravel@mbta.com">howtotravel@mbta.com</a>.</p>  
+
         <h2>Sign up to receive MBTA accessibility emails</h2>
-        <p>
-          Join the MBTA's Department of System-wide Accessibility email list
-          to get periodic updates on the work we're doing and alerts for
-          upcoming meetings.
-        </p>
+        <p>Join the MBTA's Department of System-wide Accessibility email list to get periodic updates on the work we're doing and alerts for upcoming meetings.</p>
 
         <!-- Button -->
         <table border="0" cellspacing="0" cellpadding="0" role="presentation">

--- a/assets/blind_html/emails/approved_in_store_emails/approved-in-store-portuguese.html
+++ b/assets/blind_html/emails/approved_in_store_emails/approved-in-store-portuguese.html
@@ -130,27 +130,21 @@
 
         <!-- Body copy -->
         <h1>O Blind Access CharlieCard está pronto!</h1>
-        
-        <p>
-          Visite a CharlieCard Store, localizada na Downtown Crossing Station, no saguão subterrâneo entre as linhas Vermelha e
-          Laranja: 7 Chauncy Street, Boston, MA 02111.
-        </p>
-
-        <p>
-          Para acessar a CharlieCard Store de fora da estação, use o elevador acessível dentro do edifício em 101 Arch Street. 
-        </p>
-
-        <p>
-          <a href="https://www.mbta.com/fares/charliecard-store">Visualizar horário de funcionamento da CharlieCard Store</a>
-        </p>
-
+        <p>Visite a CharlieCard Store, localizada na Downtown Crossing Station, no saguão subterrâneo entre as linhas Vermelha e Laranja: 7 Chauncy Street, Boston, MA 02111.</p>
+        <p>Para acessar a CharlieCard Store de fora da estação, use o elevador acessível dentro do edifício em 101 Arch Street.</p>
+        <p><a href="https://www.mbta.com/fares/charliecard-store">Visualizar horário de funcionamento da CharlieCard Store</a></p>
         <p>Não é necessário agendar a retirada do cartão.</p>
+
+        <h2>Sobre o cartão</h2>
+        <ul>
+          <li>Você (e um guia visual) podem usar o cartão Blind Access CharlieCard gratuitamente em todos os serviços de linhas fixas da MBTA (ônibus, metrô, trem e balsa). Animais de serviço são sempre permitidos na MBTA.</li>
+          <li>Se o cartão ficar danificado, for perdido ou roubado, solicite um outro cartão pelo modo online ou ligando para o Atendimento ao cliente no número 617-222-3200.</li>
+          <li><strong><span class="formElementOnEditor" contenteditable="false" data-row-name="element205-hiddenTitle">Generated Content: Card Duration Text<em><small>(no title)</small></em></span></strong></li>
+        </ul>
 
         <h2>Dúvidas?</h2>
 
-        <p>
-          Contate o <a href="https://www.mbta.com/customer-support">Atendimento ao cliente usando o formulário on-line</a> ou ligue para os números abaixo.
-        </p>
+        <p>Contate o <a href="https://www.mbta.com/customer-support">Atendimento ao cliente usando o formulário on-line</a> ou ligue para os números abaixo.</p>
 
         <p>
           Segunda a sexta: Das 6h30 às 20h00<br />
@@ -163,10 +157,11 @@
           TTY: <a href="tel:617-222-5146">617-222-5146</a>
         </p>
 
+        <h2>Gostaria de saber mais sobre o T?</h2>
+        <p>Nossos Travel Trainers (orientadores de viagens) no <a href="https://www.mbta.com/accessibility/mbta-mobility-center">Mobility Center</a> (Centro de Mobilidade) estão prontos para ajudar. Para saber como usar o T de forma segura e independente, planejar a sua viagem, usar os seus aplicativos móveis e ter acesso a outros serviços de trânsito, entre em contato pelo telefone <a href="tel:617-337-2756">617-337-2756</a> ou pelo e-mail <a href="mailto:howtotravel@mbta.com">howtotravel@mbta.com</a>.</p>
+
         <h2>Inscreva-se para receber e-mails de acessibilidade da MBTA</h2>
-        <p>
-          Faça parte da lista de e-mails do Departamento de Acessibilidade da MBTA para obter atualizações periódicas sobre o trabalho que estamos realizando e alertas para as próximas reuniões.
-        </p>
+        <p>Faça parte da lista de e-mails do Departamento de Acessibilidade da MBTA para obter atualizações periódicas sobre o trabalho que estamos realizando e alertas para as próximas reuniões.</p>  
 
         <!-- Button -->
         <table border="0" cellspacing="0" cellpadding="0" role="presentation">

--- a/assets/blind_html/emails/approved_in_store_emails/approved-in-store-spanish.html
+++ b/assets/blind_html/emails/approved_in_store_emails/approved-in-store-spanish.html
@@ -130,21 +130,17 @@
 
         <!-- Body copy -->
         <h1>¡Su tarjeta CharlieCard de acceso para personas ciegas está lista!</h1>
-        <p>
-          Visite la tienda CharlieCard, situada en la estación Downtown Crossing, en el vestíbulo subterráneo entre la Red Line y
-          la Orange Line: 7 Chauncy Street, Boston, MA 02111.
-        </p>
-
-        <p>
-          Para acceder a la Tienda CharlieCard desde el exterior de la estación, utilice el ascensor accesible que se encuentra en
-          el interior del edificio de 101 Arch Street.
-        </p>
-
-        <p>
-          <a href="https://www.mbta.com/fares/charliecard-store">Consultar el horario de la Tienda CharlieCard</a>
-        </p>
-
+        <p>Visite la tienda CharlieCard, situada en la estación Downtown Crossing, en el vestíbulo subterráneo entre la Red Line y la Orange Line: 7 Chauncy Street, Boston, MA 02111.</p>
+        <p>Para acceder a la Tienda CharlieCard desde el exterior de la estación, utilice el ascensor accesible que se encuentra en el interior del edificio de 101 Arch Street.</p>
+        <p><a href="https://www.mbta.com/fares/charliecard-store">Consultar el horario de la Tienda CharlieCard</a></p>
         <p>No necesita una cita para recoger su tarjeta.</p>
+
+        <h2>Acerca de su tarjeta</h2>
+        <ul>
+          <li>Usted (y un guía vidente) pueden utilizar su CharlieCard de acceso para ciegos de forma gratuita en todos los servicios de rutas fijas de la MBTA (autobús, metro, tren suburbano y ferry). Los animales de servicio están siempre permitidos en la MBTA.</li>
+          <li>Si su tarjeta se estropea, se pierde o se la roban, puede solicitar una tarjeta de reemplazo mediante la solicitud en línea o llamando al servicio de atención al cliente al 617-222-3200.</li>
+          <li><strong><span class="formElementOnEditor" contenteditable="false" data-row-name="element205-hiddenTitle">Generated Content: Card Duration Text<em><small>(no title)</small></em></span></strong></li>
+        </ul>
 
         <h2>¿Preguntas?</h2>
 
@@ -166,12 +162,11 @@
           Teletipo TTY: <a href="tel:617-222-5146">617-222-5146</a>
         </p>
 
-        <h2>Inscríbase para recibir correos electrónicos sobre la accesibilidad de la MBTA</h2>
+        <h2>¿Quiere saber más sobre la T?</h2>
+        <p>Nuestros entrenadores de viaje en el <a href="https://www.mbta.com/accessibility/mbta-mobility-center">Mobility Center</a> (Centro de Movilidad) están dispuestos a ayudarle. Para saber cómo viajar en la T de forma segura e independiente, planificar su viaje, utilizar las aplicaciones móviles y acceder a otros servicios de tránsito, póngase en contacto con el <a href="tel:617-337-2756">617-337-2756</a> o escriba a <a href="mailto:howtotravel@mbta.com">howtotravel@mbta.com</a>.</p>
 
-        <p>
-          Suscríbase a la lista de correo electrónico del Departamento de Accesibilidad del Sistema de la MBTA para recibir
-          actualizaciones periódicas sobre el trabajo que estamos realizando y alertas sobre las próximas reuniones.
-        </p>
+        <h2>Inscríbase para recibir correos electrónicos sobre la accesibilidad de la MBTA</h2>
+        <p>Únase a la lista de correo electrónico del Departamento de Accesibilidad del Sistema de la MBTA para recibir actualizaciones periódicas sobre el trabajo que estamos realizando y alertas sobre las próximas reuniones.</p>
 
         <!-- Button -->
         <table border="0" cellspacing="0" cellpadding="0" role="presentation">

--- a/assets/blind_html/form_elements/blind-access-form-fields.html
+++ b/assets/blind_html/form_elements/blind-access-form-fields.html
@@ -834,7 +834,7 @@
         target="_blank">Tienda CharlieCard <i class="fa fa-external-link" aria-hidden="true"></i></a>, visite el sitio web de la MBTA.</p>
 
 <!-- Portuguese -->
-<p>"A CharlieCard Store está localizada na Downtown Crossing Station, no saguão subterrâneo entre as linhas Vermelha e Laranja: 7 Chauncy Street, Boston, MA 02111"</p>
+<p>A CharlieCard Store está localizada na Downtown Crossing Station, no saguão subterrâneo entre as linhas Vermelha e Laranja: 7 Chauncy Street, Boston, MA 02111</p>
 
 <p>Para saber o horário de funcionamento e outras informações sobre a <a href="https://www.mbta.com/fares/charliecard-store"
         target="_blank">CharlieCard Store <i class="fa fa-external-link" aria-hidden="true"></i></a>, visite o site da MBTA.</p>
@@ -999,3 +999,13 @@
 
 <!-- NO EMAIL OR PHONE NOTIFICATION | FORM ELEMENT 200 | * ADMIN ONLY * -->
 <p>The applicant did not provide their phone number or email address.</p>
+
+<!-- NAME CHANGE REVIEW APPLICATION CALLOUT | FORM ELEMENT 203 | * ADMIN ONLY * -->
+<div style="background-image: initial; background-attachment: initial; background-color: rgba(238, 238, 238, 1); border: 1px solid rgba(204, 204, 204, 1); padding: 5px 10px">
+    <span style="font-size: 11pt"><span style="line-height: 107%"><i class="fa fa-id-card-o" aria-hidden="true"></i> The applicant's name has changed since their last card.</span></span>
+</div>
+
+<!-- NAME CHANGE PREPARE CARD CALLOUT | FORM ELEMENT 204 | * ADMIN ONLY * -->
+<div style="background-image: initial; background-attachment: initial; background-color: rgba(238, 238, 238, 1); border: 1px solid rgba(204, 204, 204, 1); padding: 5px 10px">
+    <span style="font-size: 11pt"><span style="line-height: 107%"><i class="fa fa-id-card-o" aria-hidden="true"></i> The applicant's name has changed since their last card. <strong><span class="formElementOnEditor" contenteditable="false" data-row-name="element202-hiddenTitle">Personal Information: Name on previous card (require...<em><small>(no title)</small></em></span></strong> is recorded as the name on the prior card.</span></span>
+</div>

--- a/assets/blind_html/pdfs/in_store_slips/in-store-slip-chinese-simplified.html
+++ b/assets/blind_html/pdfs/in_store_slips/in-store-slip-chinese-simplified.html
@@ -1,36 +1,32 @@
-<div style="margin:0; padding: 0"><img
-        src="https://mbta.prod.simpligov.com/prod/portal/file/51d7628117ce4c0c9cb0000188390b62.png?t=1633355953036"
-        style="width: 335.4px; height: 62.4px; margin-left: 8px; margin-top: 6px" />
-    <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">MBTA Blind Access CharlieCard
-    </p>
+<div style="margin:0; padding: 0"><img src="https://mbta.prod.simpligov.com/prod/portal/file/51d7628117ce4c0c9cb0000188390b62.png?t=1633355953036" style="width: 335.4px; height: 62.4px; margin-left: 8px; margin-top: 6px" />
+    <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">MBTA Blind Access CharlieCard</p>
+    <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">Order date (订购日期): <span class="formElementOnEditor" contenteditable="false" data-row-name="element94-hiddenTitle">Prepare Card: Date card prepared<em><small>(no title)</small></em></span></p>
 
-    <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">Order date (订购日期): <span
-            class="formElementOnEditor" contenteditable="false" data-row-name="element94-hiddenTitle">Prepare Card:
-            Date card prepared<em><small>(no title)</small></em></span></p>
-
-    <p style="font-size: 16px; font-family: Arial; margin: 43px 0 2px 62px; padding: 0;"><span
-            class="formElementOnEditor" contenteditable="false" data-row-name="element15-hiddenTitle">Personal
-            Information: First name (required)<em><small>(no title)</small></em></span>&nbsp;<span
-            class="formElementOnEditor" contenteditable="false" data-row-name="element16-hiddenTitle">Personal
-            Information: Last name (required)<em><small>(no title)</small></em></span></p>
-
+    <p style="font-size: 16px; font-family: Arial; margin: 43px 0 2px 62px; padding: 0;"><span class="formElementOnEditor" contenteditable="false" data-row-name="element15-hiddenTitle">Personal Information: First name (required)<em><small>(no title)</small></em></span>&nbsp;<span class="formElementOnEditor" contenteditable="false" data-row-name="element16-hiddenTitle">Personal Information: Last name (required)<em><small>(no title)</small></em></span></p>
     <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;">7 Chauncy Street</p>
-
     <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;">Boston, MA 02111</p>
 
     <hr style="margin: 56px 0 0 0; padding: 0;" />
-    <h1
-        style="font-size: 27.3px; font-family: Arial; font-weight: 700; margin-top: 48px; margin-left: 16px; padding: 0;">
+    <h1 style="font-size: 27.3px; font-family: Arial; font-weight: 700; margin-top: 48px; margin-left: 16px; padding: 0;">
         你的盲人乘车查理卡</h1>
 
     <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;"><strong>序号</strong><br />
-        <span class="formElementOnEditor" contenteditable="false" data-row-name="element90-hiddenTitle">Prepare Card:
-            New serial card number (requir...<em><small>(no title)</small></em></span>
+        <span class="formElementOnEditor" contenteditable="false" data-row-name="element90-hiddenTitle">Prepare Card: New serial card number (requir...<em><small>(no title)</small></em></span>
     </p>
 
     <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;">
         如果你的卡丢失&#12289被盗或损坏, 你将需要此号码。</p>
 
+    <p>&nbsp;</p>
+
+    <h2 style="font-size: 20.8px; font-family: Arial; font-weight: 700; margin-left: 16px; padding: 0;">
+        <strong>卡片时长</strong>
+    </h2>
+    
+    <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;">
+        <span class="formElementOnEditor" contenteditable="false" data-row-name="element205-hiddenTitle">Generated Content: Card Duration Text<em><small>(no title)</small></em></span>
+    </p>
+    
     <p>&nbsp;</p>
 
     <h2 style="font-size: 20.8px; font-family: Arial; font-weight: 700; margin-left: 16px; padding: 0;">

--- a/assets/blind_html/pdfs/in_store_slips/in-store-slip-chinese-traditional.html
+++ b/assets/blind_html/pdfs/in_store_slips/in-store-slip-chinese-traditional.html
@@ -1,36 +1,32 @@
-<div style="margin:0; padding: 0"><img
-        src="https://mbta.prod.simpligov.com/prod/portal/file/51d7628117ce4c0c9cb0000188390b62.png?t=1633355953036"
-        style="width: 335.4px; height: 62.4px; margin-left: 8px; margin-top: 6px" />
-    <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">MBTA Blind Access CharlieCard
-    </p>
+<div style="margin:0; padding: 0"><img src="https://mbta.prod.simpligov.com/prod/portal/file/51d7628117ce4c0c9cb0000188390b62.png?t=1633355953036" style="width: 335.4px; height: 62.4px; margin-left: 8px; margin-top: 6px" />
+    <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">MBTA Blind Access CharlieCard</p>
+    <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">Order date (訂購日期): <span class="formElementOnEditor" contenteditable="false" data-row-name="element94-hiddenTitle">Prepare Card: Date card prepared<em><small>(no title)</small></em></span></p>
 
-    <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">Order date (訂購日期): <span
-            class="formElementOnEditor" contenteditable="false" data-row-name="element94-hiddenTitle">Prepare Card:
-            Date card prepared<em><small>(no title)</small></em></span></p>
-
-    <p style="font-size: 16px; font-family: Arial; margin: 43px 0 2px 62px; padding: 0;"><span
-            class="formElementOnEditor" contenteditable="false" data-row-name="element15-hiddenTitle">Personal
-            Information: First name (required)<em><small>(no title)</small></em></span>&nbsp;<span
-            class="formElementOnEditor" contenteditable="false" data-row-name="element16-hiddenTitle">Personal
-            Information: Last name (required)<em><small>(no title)</small></em></span></p>
-
+    <p style="font-size: 16px; font-family: Arial; margin: 43px 0 2px 62px; padding: 0;"><span class="formElementOnEditor" contenteditable="false" data-row-name="element15-hiddenTitle">Personal Information: First name (required)<em><small>(no title)</small></em></span>&nbsp;<span class="formElementOnEditor" contenteditable="false" data-row-name="element16-hiddenTitle">Personal Information: Last name (required)<em><small>(no title)</small></em></span></p>
     <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;">7 Chauncy Street</p>
-
     <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;">Boston, MA 02111</p>
 
     <hr style="margin: 56px 0 0 0; padding: 0;" />
-    <h1
-        style="font-size: 27.3px; font-family: Arial; font-weight: 700; margin-top: 48px; margin-left: 16px; padding: 0;">
+    <h1 style="font-size: 27.3px; font-family: Arial; font-weight: 700; margin-top: 48px; margin-left: 16px; padding: 0;">
         你的盲人乘車查理卡</h1>
 
     <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;"><strong>序號</strong><br />
-        <span class="formElementOnEditor" contenteditable="false" data-row-name="element90-hiddenTitle">Prepare Card:
-            New serial card number (requir...<em><small>(no title)</small></em></span>
+        <span class="formElementOnEditor" contenteditable="false" data-row-name="element90-hiddenTitle">Prepare Card: New serial card number (requir...<em><small>(no title)</small></em></span>
     </p>
 
     <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;">
         如果你的卡丟失, 被盜或損壞, 你將需要此號碼。</p>
 
+    <p>&nbsp;</p>
+
+    <h2 style="font-size: 20.8px; font-family: Arial; font-weight: 700; margin-left: 16px; padding: 0;">
+        <strong>卡有效期 </strong>
+    </h2>
+    
+    <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;">
+        <span class="formElementOnEditor" contenteditable="false" data-row-name="element205-hiddenTitle">Generated Content: Card Duration Text<em><small>(no title)</small></em></span>
+    </p>
+    
     <p>&nbsp;</p>
 
     <h2 style="font-size: 20.8px; font-family: Arial; font-weight: 700; margin-left: 16px; padding: 0;">

--- a/assets/blind_html/pdfs/in_store_slips/in-store-slip-english.html
+++ b/assets/blind_html/pdfs/in_store_slips/in-store-slip-english.html
@@ -1,21 +1,8 @@
-<div style="margin:0; padding: 0"><img
-        src="https://mbta.prod.simpligov.com/prod/portal/file/51d7628117ce4c0c9cb0000188390b62.png?t=1633355953036"
-        style="width: 335.4px; height: 62.4px; margin-left: 8px; margin-top: 6px" />
-    <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">MBTA Blind Access CharlieCard
-    </p>
-
-    <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">Order date: <span
-            class="formElementOnEditor" contenteditable="false" data-row-name="element94-hiddenTitle">Prepare Card:
-            Date card prepared<em><small>(no title)</small></em></span></p>
-
-    <p style="font-size: 16px; font-family: Arial; margin: 43px 0 2px 62px; padding: 0;"><span
-            class="formElementOnEditor" contenteditable="false" data-row-name="element15-hiddenTitle">Personal
-            Information: First name (required)<em><small>(no title)</small></em></span>&nbsp;<span
-            class="formElementOnEditor" contenteditable="false" data-row-name="element16-hiddenTitle">Personal
-            Information: Last name (required)<em><small>(no title)</small></em></span></p>
-
+<div style="margin:0; padding: 0"><img src="https://mbta.prod.simpligov.com/prod/portal/file/51d7628117ce4c0c9cb0000188390b62.png?t=1633355953036" style="width: 335.4px; height: 62.4px; margin-left: 8px; margin-top: 6px" />
+    <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">MBTA Blind Access CharlieCard</p>
+    <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">Order date: <span class="formElementOnEditor" contenteditable="false" data-row-name="element94-hiddenTitle">Prepare Card: Date card prepared<em><small>(no title)</small></em></span></p>
+    <p style="font-size: 16px; font-family: Arial; margin: 43px 0 2px 62px; padding: 0;"><span class="formElementOnEditor" contenteditable="false" data-row-name="element15-hiddenTitle">Personal Information: First name (required)<em><small>(no title)</small></em></span>&nbsp;<span class="formElementOnEditor" contenteditable="false" data-row-name="element16-hiddenTitle">Personal Information: Last name (required)<em><small>(no title)</small></em></span></p>
     <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;">7 Chauncy Street</p>
-
     <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;">Boston, MA 02111</p>
 
     <hr style="margin: 56px 0 0 0; padding: 0;" />
@@ -24,13 +11,22 @@
         Your Blind Access CharlieCard</h1>
 
     <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;"><strong>Serial number</strong><br />
-        <span class="formElementOnEditor" contenteditable="false" data-row-name="element90-hiddenTitle">Prepare Card:
-            New serial card number (requir...<em><small>(no title)</small></em></span>
+        <span class="formElementOnEditor" contenteditable="false" data-row-name="element90-hiddenTitle">Prepare Card: New serial card number (requir...<em><small>(no title)</small></em></span>
     </p>
 
     <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;">
         You will need this number if your card is lost, stolen, or damaged.</p>
 
+    <p>&nbsp;</p>
+
+    <h2 style="font-size: 20.8px; font-family: Arial; font-weight: 700; margin-left: 16px; padding: 0;">
+        <strong>Card duration</strong>
+    </h2>
+    
+    <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;">
+        <span class="formElementOnEditor" contenteditable="false" data-row-name="element205-hiddenTitle">Generated Content: Card Duration Text<em><small>(no title)</small></em></span>
+    </p>
+    
     <p>&nbsp;</p>
 
     <h2 style="font-size: 20.8px; font-family: Arial; font-weight: 700; margin-left: 16px; padding: 0;">

--- a/assets/blind_html/pdfs/in_store_slips/in-store-slip-portuguese.html
+++ b/assets/blind_html/pdfs/in_store_slips/in-store-slip-portuguese.html
@@ -1,36 +1,33 @@
-<div style="margin:0; padding: 0"><img
-        src="https://mbta.prod.simpligov.com/prod/portal/file/51d7628117ce4c0c9cb0000188390b62.png?t=1633355953036"
-        style="width: 335.4px; height: 62.4px; margin-left: 8px; margin-top: 6px" />
-    <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">MBTA Blind Access CharlieCard
-    </p>
+<div style="margin:0; padding: 0"><img src="https://mbta.prod.simpligov.com/prod/portal/file/51d7628117ce4c0c9cb0000188390b62.png?t=1633355953036" style="width: 335.4px; height: 62.4px; margin-left: 8px; margin-top: 6px" />
+    <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">MBTA Blind Access CharlieCard</p>
 
-    <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">Order date (data do pedido): <span
-            class="formElementOnEditor" contenteditable="false" data-row-name="element94-hiddenTitle">Prepare Card:
-            Date card prepared<em><small>(no title)</small></em></span></p>
+    <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">Order date (data do pedido): <span class="formElementOnEditor" contenteditable="false" data-row-name="element94-hiddenTitle">Prepare Card: Date card prepared<em><small>(no title)</small></em></span></p>
 
-    <p style="font-size: 16px; font-family: Arial; margin: 43px 0 2px 62px; padding: 0;"><span
-            class="formElementOnEditor" contenteditable="false" data-row-name="element15-hiddenTitle">Personal
-            Information: First name (required)<em><small>(no title)</small></em></span>&nbsp;<span
-            class="formElementOnEditor" contenteditable="false" data-row-name="element16-hiddenTitle">Personal
-            Information: Last name (required)<em><small>(no title)</small></em></span></p>
-
+    <p style="font-size: 16px; font-family: Arial; margin: 43px 0 2px 62px; padding: 0;"><span class="formElementOnEditor" contenteditable="false" data-row-name="element15-hiddenTitle">Personal Information: First name (required)<em><small>(no title)</small></em></span>&nbsp;<span class="formElementOnEditor" contenteditable="false" data-row-name="element16-hiddenTitle">Personal Information: Last name (required)<em><small>(no title)</small></em></span></p>
     <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;">7 Chauncy Street</p>
-
     <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;">Boston, MA 02111</p>
 
     <hr style="margin: 56px 0 0 0; padding: 0;" />
-    <h1
-        style="font-size: 27.3px; font-family: Arial; font-weight: 700; margin-top: 48px; margin-left: 16px; padding: 0;">
+    <h1 style="font-size: 27.3px; font-family: Arial; font-weight: 700; margin-top: 48px; margin-left: 16px; padding: 0;">
         O Blind Access CharlieCard</h1>
 
     <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;"><strong>Número de série</strong><br />
-        <span class="formElementOnEditor" contenteditable="false" data-row-name="element90-hiddenTitle">Prepare Card:
-            New serial card number (requir...<em><small>(no title)</small></em></span>
+        <span class="formElementOnEditor" contenteditable="false" data-row-name="element90-hiddenTitle">Prepare Card: New serial card number (requir...<em><small>(no title)</small></em></span>
     </p>
 
     <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;">
         Precisará desse número se o cartão for perdido, roubado ou danificado.</p>
 
+    <p>&nbsp;</p>
+
+    <h2 style="font-size: 20.8px; font-family: Arial; font-weight: 700; margin-left: 16px; padding: 0;">
+        <strong>Duração do cartão</strong>
+    </h2>
+    
+    <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;">
+        <span class="formElementOnEditor" contenteditable="false" data-row-name="element205-hiddenTitle">Generated Content: Card Duration Text<em><small>(no title)</small></em></span>
+    </p>
+    
     <p>&nbsp;</p>
 
     <h2 style="font-size: 20.8px; font-family: Arial; font-weight: 700; margin-left: 16px; padding: 0;">

--- a/assets/blind_html/pdfs/in_store_slips/in-store-slip-spanish.html
+++ b/assets/blind_html/pdfs/in_store_slips/in-store-slip-spanish.html
@@ -1,35 +1,32 @@
-<div style="margin:0; padding: 0"><img
-        src="https://mbta.prod.simpligov.com/prod/portal/file/51d7628117ce4c0c9cb0000188390b62.png?t=1633355953036"
-        style="width: 335.4px; height: 62.4px; margin-left: 8px; margin-top: 6px" />
+<div style="margin:0; padding: 0"><img src="https://mbta.prod.simpligov.com/prod/portal/file/51d7628117ce4c0c9cb0000188390b62.png?t=1633355953036" style="width: 335.4px; height: 62.4px; margin-left: 8px; margin-top: 6px" />
     <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">MBTA Blind Access CharlieCard</p>
+    <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">Order date (fecha de la solicitud): <span class="formElementOnEditor" contenteditable="false" data-row-name="element94-hiddenTitle">Prepare Card: Date card prepared<em><small>(no title)</small></em></span></p>
 
-    <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">Order date (fecha de la solicitud): <span
-            class="formElementOnEditor" contenteditable="false" data-row-name="element94-hiddenTitle">Prepare Card:
-            Date card prepared<em><small>(no title)</small></em></span></p>
-
-    <p style="font-size: 16px; font-family: Arial; margin: 43px 0 2px 62px; padding: 0;"><span
-            class="formElementOnEditor" contenteditable="false" data-row-name="element15-hiddenTitle">Personal
-            Information: First name (required)<em><small>(no title)</small></em></span>&nbsp;<span
-            class="formElementOnEditor" contenteditable="false" data-row-name="element16-hiddenTitle">Personal
-            Information: Last name (required)<em><small>(no title)</small></em></span></p>
-
+    <p style="font-size: 16px; font-family: Arial; margin: 43px 0 2px 62px; padding: 0;"><span class="formElementOnEditor" contenteditable="false" data-row-name="element15-hiddenTitle">Personal Information: First name (required)<em><small>(no title)</small></em></span>&nbsp;<span class="formElementOnEditor" contenteditable="false" data-row-name="element16-hiddenTitle">Personal Information: Last name (required)<em><small>(no title)</small></em></span></p>
     <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;">7 Chauncy Street</p>
-
     <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;">Boston, MA 02111</p>
 
     <hr style="margin: 56px 0 0 0; padding: 0;" />
-    <h1
-        style="font-size: 27.3px; font-family: Arial; font-weight: 700; margin-top: 48px; margin-left: 16px; padding: 0;">
+    <h1 style="font-size: 27.3px; font-family: Arial; font-weight: 700; margin-top: 48px; margin-left: 16px; padding: 0;">
         Su Blind Access CharlieCard</h1>
 
     <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;"><strong>Número de serie</strong><br />
-        <span class="formElementOnEditor" contenteditable="false" data-row-name="element90-hiddenTitle">Prepare Card:
-            New serial card number (requir...<em><small>(no title)</small></em></span>
+        <span class="formElementOnEditor" contenteditable="false" data-row-name="element90-hiddenTitle">Prepare Card: New serial card number (requir...<em><small>(no title)</small></em></span>
     </p>
 
     <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;">
         Necesitará este número en caso de pérdida, robo o daño de su tarjeta.</p>
 
+    <p>&nbsp;</p>
+
+    <h2 style="font-size: 20.8px; font-family: Arial; font-weight: 700; margin-left: 16px; padding: 0;">
+        <strong>Duración de la tarjeta</strong>
+    </h2>
+    
+    <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;">
+        <span class="formElementOnEditor" contenteditable="false" data-row-name="element205-hiddenTitle">Generated Content: Card Duration Text<em><small>(no title)</small></em></span>
+    </p>
+    
     <p>&nbsp;</p>
 
     <h2 style="font-size: 20.8px; font-family: Arial; font-weight: 700; margin-left: 16px; padding: 0;">

--- a/assets/blind_html/pdfs/mailing_slips/mail-slip-chinese-simplified.html
+++ b/assets/blind_html/pdfs/mailing_slips/mail-slip-chinese-simplified.html
@@ -1,49 +1,33 @@
-<div style="margin:0px; padding: 0"><img alt="MBTA logo"
-        src="https://mbta.prod.simpligov.com/prod/portal/file/51d7628117ce4c0c9cb0000188390b62.png?t=1633355953036"
-        style="width: 335.4px; height: 62.4px; margin-left: 8px; margin-top: 6px" />
-    <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">MBTA Blind Access
-        CharlieCard
-    </p>
+<div style="margin:0px; padding: 0"><img alt="MBTA logo" src="https://mbta.prod.simpligov.com/prod/portal/file/51d7628117ce4c0c9cb0000188390b62.png?t=1633355953036" style="width: 335.4px; height: 62.4px; margin-left: 8px; margin-top: 6px" />
+    <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">MBTA Blind Access CharlieCard</p>
+    <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">Order date (订购日期): <span class="formElementOnEditor" contenteditable="false" data-row-name="element94-hiddenTitle">Prepare Card: Date card prepared<em><small>(no title)</small></em></span></p>
 
-    <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">Order date (订购日期): <span
-            class="formElementOnEditor" contenteditable="false" data-row-name="element94-hiddenTitle">Prepare Card:
-            Date card prepared<em><small>(no title)</small></em></span></p>
-
-    <p style="font-size: 16px; font-family: Arial; margin: 43px 0 2px 62px; padding: 0;"><span
-            class="formElementOnEditor" contenteditable="false" data-row-name="element15-hiddenTitle">Personal
-            Information: First name (required)<em><small>(no title)</small></em></span>&nbsp;<span
-            class="formElementOnEditor" contenteditable="false" data-row-name="element16-hiddenTitle">Personal
-            Information: Last name (required)<em><small>(no title)</small></em></span></p>
-
-    <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;"><span class="formElementOnEditor"
-            contenteditable="false" data-row-name="element44-hiddenTitle">Address: Street Address
-            (required)<em><small>(no title)</small></em></span></p>
-
-    <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;"><span class="formElementOnEditor"
-            contenteditable="false" data-row-name="element45-hiddenTitle">Address: Apartment, suite,
-            building<em><small>(no title)</small></em></span></p>
-
-    <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;"><span class="formElementOnEditor"
-            contenteditable="false" data-row-name="element46-hiddenTitle">Address: City (required)<em><small>(no
-                    title)</small></em></span>, <span class="formElementOnEditor" contenteditable="false"
-            data-row-name="element47-hiddenTitle">Address: State or US territory (require...<em><small>(no
-                    title)</small></em></span> <span class="formElementOnEditor" contenteditable="false"
-            data-row-name="element48-hiddenTitle">Address: Zip code (required)<em><small>(no title)</small></em></span>
-    </p>
+    <p style="font-size: 16px; font-family: Arial; margin: 43px 0 2px 62px; padding: 0;"><span class="formElementOnEditor" contenteditable="false" data-row-name="element15-hiddenTitle">Personal Information: First name (required)<em><small>(no title)</small></em></span>&nbsp;<span class="formElementOnEditor" contenteditable="false" data-row-name="element16-hiddenTitle">Personal Information: Last name (required)<em><small>(no title)</small></em></span></p>
+    <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;"><span class="formElementOnEditor" contenteditable="false" data-row-name="element44-hiddenTitle">Address: Street Address (required)<em><small>(no title)</small></em></span></p>
+    <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;"><span class="formElementOnEditor" contenteditable="false" data-row-name="element45-hiddenTitle">Address: Apartment, suite, building<em><small>(no title)</small></em></span></p>
+    <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;"><span class="formElementOnEditor" contenteditable="false" data-row-name="element46-hiddenTitle">Address: City (required)<em><small>(no title)</small></em></span>, <span class="formElementOnEditor" contenteditable="false" data-row-name="element47-hiddenTitle">Address: State or US territory (require...<em><small>(no title)</small></em></span> <span class="formElementOnEditor" contenteditable="false" data-row-name="element48-hiddenTitle">Address: Zip code (required)<em><small>(no title)</small></em></span></p>
 
     <hr style="margin: 56px 0 0 0; padding: 0;" />
-    <h1
-        style="font-size: 27.3px; font-family: Arial; font-weight: 700; margin-top: 48px; margin-left: 16px; padding: 0;">
+    <h1 style="font-size: 27.3px; font-family: Arial; font-weight: 700; margin-top: 48px; margin-left: 16px; padding: 0;">
         你的盲人乘车查理卡</h1>
 
         <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;"><strong>序号</strong><br />
-            <span class="formElementOnEditor" contenteditable="false" data-row-name="element90-hiddenTitle">Prepare Card:
-                New serial card number (requir...<em><small>(no title)</small></em></span>
+            <span class="formElementOnEditor" contenteditable="false" data-row-name="element90-hiddenTitle">Prepare Card: New serial card number (requir...<em><small>(no title)</small></em></span>
         </p>
     
         <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;">
             如果你的卡丢失, 被盗或损坏, 你将需要此号码。</p>
     
+        <p>&nbsp;</p>
+
+        <h2 style="font-size: 20.8px; font-family: Arial; font-weight: 700; margin-left: 16px; padding: 0;">
+            <strong>卡片时长</strong>
+        </h2>
+            
+        <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;">
+            <span class="formElementOnEditor" contenteditable="false" data-row-name="element205-hiddenTitle">Generated Content: Card Duration Text<em><small>(no title)</small></em></span>
+        </p>
+            
         <p>&nbsp;</p>
     
         <h2 style="font-size: 20.8px; font-family: Arial; font-weight: 700; margin-left: 16px; padding: 0;">

--- a/assets/blind_html/pdfs/mailing_slips/mail-slip-chinese-traditional.html
+++ b/assets/blind_html/pdfs/mailing_slips/mail-slip-chinese-traditional.html
@@ -1,48 +1,33 @@
-<div style="margin:0px; padding: 0"><img alt="MBTA logo"
-        src="https://mbta.prod.simpligov.com/prod/portal/file/51d7628117ce4c0c9cb0000188390b62.png?t=1633355953036"
-        style="width: 335.4px; height: 62.4px; margin-left: 8px; margin-top: 6px" />
-    <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">MBTA Blind Access
-        CharlieCard
-    </p>
+<div style="margin:0px; padding: 0"><img alt="MBTA logo" src="https://mbta.prod.simpligov.com/prod/portal/file/51d7628117ce4c0c9cb0000188390b62.png?t=1633355953036" style="width: 335.4px; height: 62.4px; margin-left: 8px; margin-top: 6px" />
+    <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">MBTA Blind Access CharlieCard</p>
+    <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">Order date (訂購日期): <span class="formElementOnEditor" contenteditable="false" data-row-name="element94-hiddenTitle">Prepare Card: Date card prepared<em><small>(no title)</small></em></span></p>
 
-    <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">Order date (訂購日期): <span
-            class="formElementOnEditor" contenteditable="false" data-row-name="element94-hiddenTitle">Prepare Card:
-            Date card prepared<em><small>(no title)</small></em></span></p>
-
-    <p style="font-size: 16px; font-family: Arial; margin: 43px 0 2px 62px; padding: 0;"><span
-            class="formElementOnEditor" contenteditable="false" data-row-name="element15-hiddenTitle">Personal
-            Information: First name (required)<em><small>(no title)</small></em></span>&nbsp;<span
-            class="formElementOnEditor" contenteditable="false" data-row-name="element16-hiddenTitle">Personal
-            Information: Last name (required)<em><small>(no title)</small></em></span></p>
-
-    <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;"><span class="formElementOnEditor"
-            contenteditable="false" data-row-name="element44-hiddenTitle">Address: Street Address
-            (required)<em><small>(no title)</small></em></span></p>
-
-    <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;"><span class="formElementOnEditor"
-            contenteditable="false" data-row-name="element45-hiddenTitle">Address: Apartment, suite,
-            building<em><small>(no title)</small></em></span></p>
-
-    <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;"><span class="formElementOnEditor"
-            contenteditable="false" data-row-name="element46-hiddenTitle">Address: City (required)<em><small>(no
-                    title)</small></em></span>, <span class="formElementOnEditor" contenteditable="false"
-            data-row-name="element47-hiddenTitle">Address: State or US territory (require...<em><small>(no
-                    title)</small></em></span> <span class="formElementOnEditor" contenteditable="false"
-            data-row-name="element48-hiddenTitle">Address: Zip code (required)<em><small>(no title)</small></em></span>
-    </p>
+    <p style="font-size: 16px; font-family: Arial; margin: 43px 0 2px 62px; padding: 0;"><span class="formElementOnEditor" contenteditable="false" data-row-name="element15-hiddenTitle">Personal Information: First name (required)<em><small>(no title)</small></em></span>&nbsp;<span class="formElementOnEditor" contenteditable="false" data-row-name="element16-hiddenTitle">Personal Information: Last name (required)<em><small>(no title)</small></em></span></p>
+    <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;"><span class="formElementOnEditor" contenteditable="false" data-row-name="element44-hiddenTitle">Address: Street Address (required)<em><small>(no title)</small></em></span></p>
+    <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;"><span class="formElementOnEditor" contenteditable="false" data-row-name="element45-hiddenTitle">Address: Apartment, suite, building<em><small>(no title)</small></em></span></p>
+    <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;"><span class="formElementOnEditor" contenteditable="false" data-row-name="element46-hiddenTitle">Address: City (required)<em><small>(no title)</small></em></span>, <span class="formElementOnEditor" contenteditable="false" data-row-name="element47-hiddenTitle">Address: State or US territory (require...<em><small>(no title)</small></em></span> <span class="formElementOnEditor" contenteditable="false" data-row-name="element48-hiddenTitle">Address: Zip code (required)<em><small>(no title)</small></em></span></p>
 
     <hr style="margin: 56px 0 0 0; padding: 0;" />
     <h1 style="font-size: 27.3px; font-family: Arial; font-weight: 700; margin-top: 48px; margin-left: 16px; padding: 0;">
         你的盲人乘車查理卡</h1>
 
     <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;"><strong>序號</strong><br />
-        <span class="formElementOnEditor" contenteditable="false" data-row-name="element90-hiddenTitle">Prepare Card:
-            New serial card number (requir...<em><small>(no title)</small></em></span>
+        <span class="formElementOnEditor" contenteditable="false" data-row-name="element90-hiddenTitle">Prepare Card: New serial card number (requir...<em><small>(no title)</small></em></span>
     </p>
 
     <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;">
         如果你的卡丟失, 被盜或損壞, 你將需要此號碼。</p>
 
+    <p>&nbsp;</p>
+
+    <h2 style="font-size: 20.8px; font-family: Arial; font-weight: 700; margin-left: 16px; padding: 0;">
+        <strong>卡有效期 </strong>
+    </h2>
+        
+    <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;">
+        <span class="formElementOnEditor" contenteditable="false" data-row-name="element205-hiddenTitle">Generated Content: Card Duration Text<em><small>(no title)</small></em></span>
+    </p>
+        
     <p>&nbsp;</p>
 
     <h2 style="font-size: 20.8px; font-family: Arial; font-weight: 700; margin-left: 16px; padding: 0;">

--- a/assets/blind_html/pdfs/mailing_slips/mail-slip-english.html
+++ b/assets/blind_html/pdfs/mailing_slips/mail-slip-english.html
@@ -1,35 +1,11 @@
-<div style="margin:0px; padding: 0"><img alt="MBTA logo"
-        src="https://mbta.prod.simpligov.com/prod/portal/file/51d7628117ce4c0c9cb0000188390b62.png?t=1633355953036"
-        style="width: 335.4px; height: 62.4px; margin-left: 8px; margin-top: 6px" />
-    <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">MBTA Blind Access
-        CharlieCard
-    </p>
+<div style="margin:0px; padding: 0"><img alt="MBTA logo" src="https://mbta.prod.simpligov.com/prod/portal/file/51d7628117ce4c0c9cb0000188390b62.png?t=1633355953036" style="width: 335.4px; height: 62.4px; margin-left: 8px; margin-top: 6px" />
+    <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">MBTA Blind Access CharlieCard</p>
+    <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">Order date: <span class="formElementOnEditor" contenteditable="false" data-row-name="element94-hiddenTitle">Prepare Card: Date card prepared<em><small>(no title)</small></em></span></p>
 
-    <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">Order date: <span
-            class="formElementOnEditor" contenteditable="false" data-row-name="element94-hiddenTitle">Prepare Card:
-            Date card prepared<em><small>(no title)</small></em></span></p>
-
-    <p style="font-size: 16px; font-family: Arial; margin: 43px 0 2px 62px; padding: 0;"><span
-            class="formElementOnEditor" contenteditable="false" data-row-name="element15-hiddenTitle">Personal
-            Information: First name (required)<em><small>(no title)</small></em></span>&nbsp;<span
-            class="formElementOnEditor" contenteditable="false" data-row-name="element16-hiddenTitle">Personal
-            Information: Last name (required)<em><small>(no title)</small></em></span></p>
-
-    <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;"><span class="formElementOnEditor"
-            contenteditable="false" data-row-name="element44-hiddenTitle">Address: Street Address
-            (required)<em><small>(no title)</small></em></span></p>
-
-    <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;"><span class="formElementOnEditor"
-            contenteditable="false" data-row-name="element45-hiddenTitle">Address: Apartment, suite,
-            building<em><small>(no title)</small></em></span></p>
-
-    <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;"><span class="formElementOnEditor"
-            contenteditable="false" data-row-name="element46-hiddenTitle">Address: City (required)<em><small>(no
-                    title)</small></em></span>, <span class="formElementOnEditor" contenteditable="false"
-            data-row-name="element47-hiddenTitle">Address: State or US territory (require...<em><small>(no
-                    title)</small></em></span> <span class="formElementOnEditor" contenteditable="false"
-            data-row-name="element48-hiddenTitle">Address: Zip code (required)<em><small>(no title)</small></em></span>
-    </p>
+    <p style="font-size: 16px; font-family: Arial; margin: 43px 0 2px 62px; padding: 0;"><span class="formElementOnEditor" contenteditable="false" data-row-name="element15-hiddenTitle">Personal Information: First name (required)<em><small>(no title)</small></em></span>&nbsp;<span class="formElementOnEditor" contenteditable="false" data-row-name="element16-hiddenTitle">Personal Information: Last name (required)<em><small>(no title)</small></em></span></p>
+    <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;"><span class="formElementOnEditor" contenteditable="false" data-row-name="element44-hiddenTitle">Address: Street Address (required)<em><small>(no title)</small></em></span></p>
+    <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;"><span class="formElementOnEditor" contenteditable="false" data-row-name="element45-hiddenTitle">Address: Apartment, suite, building<em><small>(no title)</small></em></span></p>
+    <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;"><span class="formElementOnEditor" contenteditable="false" data-row-name="element46-hiddenTitle">Address: City (required)<em><small>(no title)</small></em></span>, <span class="formElementOnEditor" contenteditable="false" data-row-name="element47-hiddenTitle">Address: State or US territory (require...<em><small>(no title)</small></em></span> <span class="formElementOnEditor" contenteditable="false" data-row-name="element48-hiddenTitle">Address: Zip code (required)<em><small>(no title)</small></em></span></p>
 
     <hr style="margin: 56px 0 0 0; padding: 0;" />
     <h1
@@ -37,13 +13,22 @@
         Your Blind Access CharlieCard</h1>
 
     <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;"><strong>Serial number</strong><br />
-        <span class="formElementOnEditor" contenteditable="false" data-row-name="element90-hiddenTitle">Prepare Card:
-            New serial card number (requir...<em><small>(no title)</small></em></span>
+        <span class="formElementOnEditor" contenteditable="false" data-row-name="element90-hiddenTitle">Prepare Card: New serial card number (requir...<em><small>(no title)</small></em></span>
     </p>
 
     <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;">You will need this number if your
         card is lost, stolen, or damaged.</p>
 
+    <p>&nbsp;</p>
+
+    <h2 style="font-size: 20.8px; font-family: Arial; font-weight: 700; margin-left: 16px; padding: 0;">
+        <strong>Card duration</strong>
+    </h2>
+        
+    <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;">
+        <span class="formElementOnEditor" contenteditable="false" data-row-name="element205-hiddenTitle">Generated Content: Card Duration Text<em><small>(no title)</small></em></span>
+    </p>
+        
     <p>&nbsp;</p>
 
     <h2 style="font-size: 20.8px; font-family: Arial; font-weight: 700; margin-left: 16px; padding: 0;">

--- a/assets/blind_html/pdfs/mailing_slips/mail-slip-portuguese.html
+++ b/assets/blind_html/pdfs/mailing_slips/mail-slip-portuguese.html
@@ -1,50 +1,34 @@
-<div style="margin:0px; padding: 0"><img alt="MBTA logo"
-        src="https://mbta.prod.simpligov.com/prod/portal/file/51d7628117ce4c0c9cb0000188390b62.png?t=1633355953036"
-        style="width: 335.4px; height: 62.4px; margin-left: 8px; margin-top: 6px" />
-    <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">MBTA Blind Access
-        CharlieCard
-    </p>
+<div style="margin:0px; padding: 0"><img alt="MBTA logo" src="https://mbta.prod.simpligov.com/prod/portal/file/51d7628117ce4c0c9cb0000188390b62.png?t=1633355953036" style="width: 335.4px; height: 62.4px; margin-left: 8px; margin-top: 6px" />
+    <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">MBTA Blind Access CharlieCard</p>
+    <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">Order date (data do pedido): <span class="formElementOnEditor" contenteditable="false" data-row-name="element94-hiddenTitle">Prepare Card: Date card prepared<em><small>(no title)</small></em></span></p>
 
-    <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">Order date (data do pedido): <span
-            class="formElementOnEditor" contenteditable="false" data-row-name="element94-hiddenTitle">Prepare Card:
-            Date card prepared<em><small>(no title)</small></em></span></p>
-
-    <p style="font-size: 16px; font-family: Arial; margin: 43px 0 2px 62px; padding: 0;"><span
-            class="formElementOnEditor" contenteditable="false" data-row-name="element15-hiddenTitle">Personal
-            Information: First name (required)<em><small>(no title)</small></em></span>&nbsp;<span
-            class="formElementOnEditor" contenteditable="false" data-row-name="element16-hiddenTitle">Personal
-            Information: Last name (required)<em><small>(no title)</small></em></span></p>
-
-    <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;"><span class="formElementOnEditor"
-            contenteditable="false" data-row-name="element44-hiddenTitle">Getting Your Card: Street Address
-            (required)<em><small>(no title)</small></em></span></p>
-
-    <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;"><span class="formElementOnEditor"
-            contenteditable="false" data-row-name="element45-hiddenTitle">Getting Your Card: Apartment, suite,
-            building<em><small>(no title)</small></em></span></p>
-
-    <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;"><span class="formElementOnEditor"
-            contenteditable="false" data-row-name="element46-hiddenTitle">Getting Your Card: City (required)<em><small>(no
-                    title)</small></em></span>, <span class="formElementOnEditor" contenteditable="false"
-            data-row-name="element47-hiddenTitle">Getting Your Card: State or US territory (require...<em><small>(no
-                    title)</small></em></span> <span class="formElementOnEditor" contenteditable="false"
-            data-row-name="element48-hiddenTitle">Getting Your Card: Zip code (required)<em><small>(no title)</small></em></span>
-    </p>
+    <p style="font-size: 16px; font-family: Arial; margin: 43px 0 2px 62px; padding: 0;"><span class="formElementOnEditor" contenteditable="false" data-row-name="element15-hiddenTitle">Personal Information: First name (required)<em><small>(no title)</small></em></span>&nbsp;<span class="formElementOnEditor" contenteditable="false" data-row-name="element16-hiddenTitle">Personal Information: Last name (required)<em><small>(no title)</small></em></span></p>
+    <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;"><span class="formElementOnEditor" contenteditable="false" data-row-name="element44-hiddenTitle">Getting Your Card: Street Address (required)<em><small>(no title)</small></em></span></p>
+    <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;"><span class="formElementOnEditor" contenteditable="false" data-row-name="element45-hiddenTitle">Getting Your Card: Apartment, suite, building<em><small>(no title)</small></em></span></p>
+    <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;"><span class="formElementOnEditor" contenteditable="false" data-row-name="element46-hiddenTitle">Getting Your Card: City (required)<em><small>(no title)</small></em></span>, <span class="formElementOnEditor" contenteditable="false" data-row-name="element47-hiddenTitle">Getting Your Card: State or US territory (require...<em><small>(no title)</small></em></span> <span class="formElementOnEditor" contenteditable="false" data-row-name="element48-hiddenTitle">Getting Your Card: Zip code (required)<em><small>(no title)</small></em></span></p>
 
     <hr style="margin: 56px 0 0 0; padding: 0;" />
-    <h1
-        style="font-size: 27.3px; font-family: Arial; font-weight: 700; margin-top: 48px; margin-left: 16px; padding: 0;">
+    <h1 style="font-size: 27.3px; font-family: Arial; font-weight: 700; margin-top: 48px; margin-left: 16px; padding: 0;">
         O Blind Access CharlieCard</h1>
 
     <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;"><strong>Número de série</strong><br />
-        <span class="formElementOnEditor" contenteditable="false" data-row-name="element90-hiddenTitle">Prepare Card:
-            New serial card number (requir...<em><small>(no title)</small></em></span>
+        <span class="formElementOnEditor" contenteditable="false" data-row-name="element90-hiddenTitle">Prepare Card: New serial card number (requir...<em><small>(no title)</small></em></span>
     </p>
 
     <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;">
         Precisará desse número se o cartão for perdido, roubado ou danificado.</p>
+        
+        <p>&nbsp;</p>
 
-    <p>&nbsp;</p>
+        <h2 style="font-size: 20.8px; font-family: Arial; font-weight: 700; margin-left: 16px; padding: 0;">
+            <strong>Duração do cartão</strong>
+        </h2>
+    
+        <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;">
+            <span class="formElementOnEditor" contenteditable="false" data-row-name="element205-hiddenTitle">Generated Content: Card Duration Text<em><small>(no title)</small></em></span>
+        </p>
+    
+        <p>&nbsp;</p>
 
     <h2 style="font-size: 20.8px; font-family: Arial; font-weight: 700; margin-left: 16px; padding: 0;">
         <strong>Dúvidas?</strong></h2>

--- a/assets/blind_html/pdfs/mailing_slips/mail-slip-spanish.html
+++ b/assets/blind_html/pdfs/mailing_slips/mail-slip-spanish.html
@@ -1,47 +1,33 @@
-<div style="margin:0px; padding: 0"><img alt="MBTA logo"
-        src="https://mbta.prod.simpligov.com/prod/portal/file/51d7628117ce4c0c9cb0000188390b62.png?t=1633355953036"
-        style="width: 335.4px; height: 62.4px; margin-left: 8px; margin-top: 6px" />
-    <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">MBTA Blind Access
-        CharlieCard
-    </p>
+<div style="margin:0px; padding: 0"><img alt="MBTA logo" src="https://mbta.prod.simpligov.com/prod/portal/file/51d7628117ce4c0c9cb0000188390b62.png?t=1633355953036" style="width: 335.4px; height: 62.4px; margin-left: 8px; margin-top: 6px" />
+    <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">MBTA Blind Access CharlieCard</p>
 
-    <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">Order date (fecha de la solicitud): <span
-            class="formElementOnEditor" contenteditable="false" data-row-name="element94-hiddenTitle">Prepare Card:
-            Date card prepared<em><small>(no title)</small></em></span></p>
+    <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">Order date (fecha de la solicitud): <span class="formElementOnEditor" contenteditable="false" data-row-name="element94-hiddenTitle">Prepare Card: Date card prepared<em><small>(no title)</small></em></span></p>
 
-    <p style="font-size: 16px; font-family: Arial; margin: 43px 0 2px 62px; padding: 0;"><span
-            class="formElementOnEditor" contenteditable="false" data-row-name="element15-hiddenTitle">Personal
-            Information: First name (required)<em><small>(no title)</small></em></span>&nbsp;<span
-            class="formElementOnEditor" contenteditable="false" data-row-name="element16-hiddenTitle">Personal
-            Information: Last name (required)<em><small>(no title)</small></em></span></p>
-
-    <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;"><span class="formElementOnEditor"
-            contenteditable="false" data-row-name="element44-hiddenTitle">Getting Your Card: Street Address
-            (required)<em><small>(no title)</small></em></span></p>
-
-    <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;"><span class="formElementOnEditor"
-            contenteditable="false" data-row-name="element45-hiddenTitle">Getting Your Card: Apartment, suite,
-            building<em><small>(no title)</small></em></span></p>
-
-    <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;"><span class="formElementOnEditor"
-            contenteditable="false" data-row-name="element46-hiddenTitle">Getting Your Card: City (required)<em><small>(no
-                    title)</small></em></span>, <span class="formElementOnEditor" contenteditable="false"
-            data-row-name="element47-hiddenTitle">Getting Your Card: State or US territory (require...<em><small>(no
-                    title)</small></em></span> <span class="formElementOnEditor" contenteditable="false"
-            data-row-name="element48-hiddenTitle">Getting Your Card: Zip code (required)<em><small>(no title)</small></em></span>
-    </p>
+        <p style="font-size: 16px; font-family: Arial; margin: 43px 0 2px 62px; padding: 0;"><span class="formElementOnEditor" contenteditable="false" data-row-name="element15-hiddenTitle">Personal Information: First name (required)<em><small>(no title)</small></em></span>&nbsp;<span class="formElementOnEditor" contenteditable="false" data-row-name="element16-hiddenTitle">Personal Information: Last name (required)<em><small>(no title)</small></em></span></p>
+        <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;"><span class="formElementOnEditor" contenteditable="false" data-row-name="element44-hiddenTitle">Getting Your Card: Street Address (required)<em><small>(no title)</small></em></span></p>
+        <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;"><span class="formElementOnEditor" contenteditable="false" data-row-name="element45-hiddenTitle">Getting Your Card: Apartment, suite, building<em><small>(no title)</small></em></span></p>
+        <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;"><span class="formElementOnEditor" contenteditable="false" data-row-name="element46-hiddenTitle">Getting Your Card: City (required)<em><small>(no title)</small></em></span>, <span class="formElementOnEditor" contenteditable="false" data-row-name="element47-hiddenTitle">Getting Your Card: State or US territory (require...<em><small>(no title)</small></em></span> <span class="formElementOnEditor" contenteditable="false" data-row-name="element48-hiddenTitle">Getting Your Card: Zip code (required)<em><small>(no title)</small></em></span></p>
+        
 
     <hr style="margin: 56px 0 0 0; padding: 0;" />
-    <h1
-        style="font-size: 27.3px; font-family: Arial; font-weight: 700; margin-top: 48px; margin-left: 16px; padding: 0;">
+    <h1 style="font-size: 27.3px; font-family: Arial; font-weight: 700; margin-top: 48px; margin-left: 16px; padding: 0;">
         Su Blind Access CharlieCard</h1>
 
     <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;"><strong>Número de serie</strong><br />
-        <span class="formElementOnEditor" contenteditable="false" data-row-name="element90-hiddenTitle">Prepare Card:
-            New serial card number (requir...<em><small>(no title)</small></em></span>
+        <span class="formElementOnEditor" contenteditable="false" data-row-name="element90-hiddenTitle">Prepare Card: New serial card number (requir...<em><small>(no title)</small></em></span>
     </p>
 
     <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;">Necesitará este número en caso de pérdida, robo o daño de su tarjeta.</p>
+
+    <p>&nbsp;</p>
+
+    <h2 style="font-size: 20.8px; font-family: Arial; font-weight: 700; margin-left: 16px; padding: 0;">
+        <strong>Duración de la tarjeta</strong>
+    </h2>
+
+    <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;">
+        <span class="formElementOnEditor" contenteditable="false" data-row-name="element205-hiddenTitle">Generated Content: Card Duration Text<em><small>(no title)</small></em></span>
+    </p>
 
     <p>&nbsp;</p>
 

--- a/assets/intake_html/emails/approved_by_mail_emails/approved-by-mail-chinese-simplified.html
+++ b/assets/intake_html/emails/approved_by_mail_emails/approved-by-mail-chinese-simplified.html
@@ -130,11 +130,9 @@
 
         <!-- Body copy -->
         <h1>您的 <span class="formElementOnEditor" contenteditable="false" data-row-name="element276-hiddenTitle">Reduced Fare In Person Application: Long Program Name<em><small>(no title)</small></em></span> CharlieCard 已寄出！</h1>
-
         <p>您的<span class="formElementOnEditor" contenteditable="false" data-row-name="element276-hiddenTitle">Reduced Fare In Person Application: Long Program Name<em><small>(no title)</small></em></span> CharlieCard 将在 3-5 个工作日内通过 USPS 送达您的邮寄地址。</p>
 
         <h2>关于您的卡</h2>
-
         <ul>
           <li>了解 <a href="https://www.mbta.com/fares/reduced">如何使用您的卡</a>。</li>
           <li>如果您的卡损坏、丢失或被盗，您可以使用在线申请或致电客户支持来申请更换卡，电话 617-222-3200。</li>
@@ -143,26 +141,24 @@
         </ul>
 
         <h2>有问题吗?</h2>
-
         <p>
           请联系<a href="https://www.mbta.com/customer-support">客户支持 (使用网上表格) </a>
           或给下列号码打电话。
         </p>
-
         <p>
           周一 &ndash; 周五: 早6:30 &ndash; 晚8点<br />
           周六 &ndash; 周日: 早8点 &ndash; 下午4点
         </p>
-
         <p>
-          <strong>主热线: </strong>
-          <a href="tel:617-222-3200">617-222-3200</a><br />
+          <strong>主热线: </strong><a href="tel:617-222-3200">617-222-3200</a><br />
           免费电话: <a href="tel:800-392-6100">800-392-6100</a><br />
           TTY: <a href="tel:617-222-5146">617-222-5146</a>
         </p>
 
-        <h2>注册以接收有关MBTA无障碍性的电子邮件</h2>
+        <h2>你是否想了解更多有关T的信息？</h2>
+        <p>我们的移动中心（<a href="https://www.mbta.com/accessibility/mbta-mobility-center">Mobility Center</a>）交通培训员随时准备为你提供帮助。要了解如何安全、独立地乘坐T、计划出行、使用移动应用程序以及获得其他交通服务，请联系<a href="tel:617-337-2756">617-337-2756</a>或<a href="mailto:howtotravel@mbta.com">howtotravel@mbta.com</a>。</p>
 
+        <h2>注册以接收有关MBTA无障碍性的电子邮件</h2>
         <p>加入MBTA的系统范围内无障碍性部门的电子邮件名单，以获取有关我们正在开展的工作的定期更新以及即将举行的会议通知。</p>
 
         <!-- Button -->

--- a/assets/intake_html/emails/approved_by_mail_emails/approved-by-mail-english.html
+++ b/assets/intake_html/emails/approved_by_mail_emails/approved-by-mail-english.html
@@ -130,11 +130,9 @@
 
         <!-- Body copy -->
         <h1>Your <span class="formElementOnEditor" contenteditable="false" data-row-name="element276-hiddenTitle">Reduced Fare In Person Application: Long Program Name<em><small>(no title)</small></em></span> CharlieCard is on its way!</h1>
-
         <p>Your <span class="formElementOnEditor" contenteditable="false" data-row-name="element276-hiddenTitle">Reduced Fare In Person Application: Long Program Name<em><small>(no title)</small></em></span> CharlieCard will arrive via USPS in 3-5 business days to your mailing address.</p>
 
         <h2>About your card</h2>
-
         <ul>
           <li>Learn <a href="https://www.mbta.com/fares/reduced">how to use your card</a>.</li>
           <li>If your card is damaged, lost, or stolen, you can request a replacement card using the online application or by calling Customer Support at 617-222-3200.</li>
@@ -149,14 +147,15 @@
           Saturday &ndash; Sunday: 8 AM &ndash; 4 PM
         </p>
         <p>
-          <strong>Main Hotline:</strong>
-          <a href="tel:617-222-3200">617-222-3200</a><br />
+          <strong>Main Hotline:</strong> <a href="tel:617-222-3200">617-222-3200</a><br />
           Toll Free: <a href="tel:800-392-6100">800-392-6100</a><br />
           TTY: <a href="tel:617-222-5146">617-222-5146</a>
         </p>
 
-        <h2>Sign up to receive MBTA accessibility emails</h2>
+        <h2>Do you want to learn more about the T?</h2>
+        <p>Our Travel Trainers at the <a href="https://www.mbta.com/accessibility/mbta-mobility-center">Mobility Center</a> are ready to assist. To learn how to ride the T safely and independently, plan your trip, use your mobile apps, and access other transit services, contact <a href="tel:617-337-2756">617-337-2756</a> or <a href="mailto:howtotravel@mbta.com">howtotravel@mbta.com</a>.</p>
 
+        <h2>Sign up to receive MBTA accessibility emails</h2>
         <p>Join the MBTA's Department of System-wide Accessibility email list to get periodic updates on the work we're doing and alerts for upcoming meetings.</p>
 
         <!-- Button -->

--- a/assets/intake_html/emails/approved_by_mail_emails/approved-by-mail-portuguese.html
+++ b/assets/intake_html/emails/approved_by_mail_emails/approved-by-mail-portuguese.html
@@ -130,11 +130,9 @@
 
         <!-- Body copy -->
         <h1>O cartão CharlieCard do <span class="formElementOnEditor" contenteditable="false" data-row-name="element276-hiddenTitle">Reduced Fare In Person Application: Long Program Name<em><small>(no title)</small></em></span> está a caminho!</h1>
-
         <p>O <span class="formElementOnEditor" contenteditable="false" data-row-name="element276-hiddenTitle">Reduced Fare In Person Application: Long Program Name<em><small>(no title)</small></em></span> CharlieCard chegará via USPS em 3-5 dias úteis ao seu endereço de correspondência.</p>
 
         <h2>Sobre o cartão</h2>
-
         <ul>
           <li>Saiba <a href="https://www.mbta.com/fares/reduced">como usar o cartão</a>.</li>
           <li>Se o cartão for danificado, perdido ou roubado, pode solicitar um cartão de substituição usando o aplicativo on-line ou ligando para o Atendimento ao Cliente pelo telefone 617-222-3200.</li>
@@ -143,23 +141,22 @@
         </ul>
 
         <h2>Dúvidas?</h2>
-
         <p>Contate o <a href="https://www.mbta.com/customer-support">Atendimento ao cliente usando o formulário on-line</a> ou ligue para os números abaixo.</p>
-
         <p>
           Segunda a sexta: Das 6h30 às 20h00<br />
           Sábado a domingo: Das 8h00 às 16h00
         </p>
-        
         <p>
           <strong>Hotline principal: </strong><a href="tel:617-222-3200">617-222-3200</a><br />
           Gratuito: <a href="tel:800-392-6100">800-392-6100</a><br />
           TTY: <a href="tel:617-222-5146">617-222-5146</a>
         </p>
 
-        <h2>Inscreva-se para receber e-mails de acessibilidade da MBTA</h2>
+        <h2>Gostaria de saber mais sobre o T?</h2>
+        <p>Nossos Travel Trainers (orientadores de viagens) no <a href="https://www.mbta.com/accessibility/mbta-mobility-center">Mobility Center</a> (Centro de Mobilidade) estão prontos para ajudar. Para saber como usar o T de forma segura e independente, planejar a sua viagem, usar os seus aplicativos móveis e ter acesso a outros serviços de trânsito, entre em contato pelo telefone <a href="tel:617-337-2756">617-337-2756</a> ou pelo e-mail <a href="mailto:howtotravel@mbta.com">howtotravel@mbta.com</a>.</p>
 
-        <p>Faça parte da lista de e-mails do Departamento de Acessibilidade da MBTA para obter atualizações periódicas sobre o trabalho que estamos realizando e alertas para as próximas reuniões.</p>
+        <h2>Inscreva-se para receber e-mails de acessibilidade da MBTA</h2>
+        <p>Faça parte da lista de e-mails do Departamento de Acessibilidade da MBTA para obter atualizações periódicas sobre o trabalho que estamos realizando e alertas para as próximas reuniões.</p>  
 
         <!-- Button -->
         <table border="0" cellspacing="0" cellpadding="0" role="presentation">

--- a/assets/intake_html/emails/approved_by_mail_emails/approved-by-mail-spanish.html
+++ b/assets/intake_html/emails/approved_by_mail_emails/approved-by-mail-spanish.html
@@ -130,11 +130,9 @@
 
         <!-- Body copy -->
         <h1>¡Su <span class="formElementOnEditor" contenteditable="false" data-row-name="element276-hiddenTitle">Reduced Fare In Person Application: Long Program Name<em><small>(no title)</small></em></span> CharlieCard está en camino!</h1>
-
         <p>Su <span class="formElementOnEditor" contenteditable="false" data-row-name="element276-hiddenTitle">Reduced Fare In Person Application: Long Program Name<em><small>(no title)</small></em></span> CharlieCard le llegará vía USPS en un plazo de 3 a 5 días hábiles a su dirección postal.</p>
 
         <h2>Información sobre su tarjeta</h2>
-
         <ul>
           <li>Aprenda <a href="https://www.mbta.com/fares/reduced">cómo usar la tarjeta</a>.</li>
           <li>En caso de que la tarjeta se dañe, extravíe o se la roben, puede solicitar una tarjeta de reemplazo mediante la solicitud en línea o llamando a Soporte al cliente al número telefónico 617-222-3200.</li>
@@ -143,14 +141,11 @@
         </ul>
 
         <h2>¿Preguntas?</h2>
-
         <p>Póngase en contacto con el <a href="https://www.mbta.com/customer-support">Servicio de atención al cliente a través de su formulario en línea</a> o llame al número que aparece a continuación.</p>
-
         <p>
           Lunes &ndash; viernes: 6:30 AM &ndash; 8 PM<br />
           Sábado &ndash; domingo: 8 AM &ndash; 4 PM
         </p>
-
         <p>
           <strong>Línea directa principal: </strong>
           <a href="tel:617-222-3200">617-222-3200</a><br />
@@ -158,8 +153,10 @@
           Teletipo TTY: <a href="tel:617-222-5146">617-222-5146</a>
         </p>
 
-        <h2>Inscríbase para recibir correos electrónicos sobre la accesibilidad de la MBTA</h2>
+        <h2>¿Quiere saber más sobre la T?</h2>
+        <p>Nuestros entrenadores de viaje en el <a href="https://www.mbta.com/accessibility/mbta-mobility-center">Mobility Center</a> (Centro de Movilidad) están dispuestos a ayudarle. Para saber cómo viajar en la T de forma segura e independiente, planificar su viaje, utilizar las aplicaciones móviles y acceder a otros servicios de tránsito, póngase en contacto con el <a href="tel:617-337-2756">617-337-2756</a> o escriba a <a href="mailto:howtotravel@mbta.com">howtotravel@mbta.com</a>.</p>
 
+        <h2>Inscríbase para recibir correos electrónicos sobre la accesibilidad de la MBTA</h2>
         <p>Únase a la lista de correo electrónico del Departamento de Accesibilidad del Sistema de la MBTA para recibir actualizaciones periódicas sobre el trabajo que estamos realizando y alertas sobre las próximas reuniones.</p>
 
         <!-- Button -->

--- a/assets/intake_html/emails/approved_in_store_emails/approved-in-store-chinese-simplified.html
+++ b/assets/intake_html/emails/approved_in_store_emails/approved-in-store-chinese-simplified.html
@@ -142,24 +142,32 @@
 
         <p>您无需预约即可领取您的卡。</p>
 
-        <h2>有问题吗?</h2>
+        <h2>关于您的卡</h2>
+        <ul>
+          <li>了解 <a href="https://www.mbta.com/fares/reduced">如何使用您的卡</a>。</li>
+          <li>如果您的卡损坏、丢失或被盗，您可以使用在线申请或致电客户支持来申请更换卡，电话 617-222-3200。</li>
+          <li>如果您的卡是续卡或换卡，您的月票和旧卡中的余额将自动转移到您的新卡中。</li>
+          <li><strong><span class="formElementOnEditor" contenteditable="false" data-row-name="element206-hiddenTitle">Generated Content: Card Duration Text<em><small>(no title)</small></em></span></strong></li>
+        </ul>
 
+        <h2>有问题吗?</h2>
         <p>
           请联系<a href="https://www.mbta.com/customer-support">客户支持 (使用网上表格) </a>
           或给下列号码打电话。
         </p>
-
         <p>
           周一 &ndash; 周五: 早6:30 &ndash; 晚8点<br />
           周六 &ndash; 周日: 早8点 &ndash; 下午4点
         </p>
-
         <p>
           <strong>主热线: </strong>
           <a href="tel:617-222-3200">617-222-3200</a><br />
           免费电话: <a href="tel:800-392-6100">800-392-6100</a><br />
           TTY: <a href="tel:617-222-5146">617-222-5146</a>
         </p>
+
+        <h2>你是否想了解更多有关T的信息？</h2>
+        <p>我们的移动中心（<a href="https://www.mbta.com/accessibility/mbta-mobility-center">Mobility Center</a>）交通培训员随时准备为你提供帮助。要了解如何安全、独立地乘坐T、计划出行、使用移动应用程序以及获得其他交通服务，请联系<a href="tel:617-337-2756">617-337-2756</a>或<a href="mailto:howtotravel@mbta.com">howtotravel@mbta.com</a>。</p>
 
         <h2>注册以接收有关MBTA无障碍性的电子邮件</h2>
         <p>加入MBTA的系统范围内无障碍性部门的电子邮件名单，以获取有关我们正在开展的工作的定期更新以及即将举行的会议通知。</p>

--- a/assets/intake_html/emails/approved_in_store_emails/approved-in-store-english.html
+++ b/assets/intake_html/emails/approved_in_store_emails/approved-in-store-english.html
@@ -142,26 +142,31 @@
 
         <p>You do not need an appointment to pick up your card.</p>
 
+        <h2>About your card</h2>
+        <ul>
+          <li>Learn <a href="https://www.mbta.com/fares/reduced">how to use your card</a>.</li>
+          <li>If your card is damaged, lost, or stolen, you can request a replacement card using the online application or by calling Customer Support at 617-222-3200.</li>
+          <li>If your card was a renewal or replacement, your monthly pass and balance from your old card will be automatically transferred to your new card.</li>
+          <li><strong><span class="formElementOnEditor" contenteditable="false" data-row-name="element206-hiddenTitle">Generated Content: Card Duration Text<em><small>(no title)</small></em></span></strong></li>
+        </ul>
+
         <h2>Questions?</h2>
         <p>Contact <a href="https://www.mbta.com/customer-support">Customer Support using their online form</a> or call the number below.</p>
-        
         <p>
           Monday &ndash; Friday: 6:30 AM &ndash; 8 PM<br />
           Saturday &ndash; Sunday: 8 AM &ndash; 4 PM
         </p>
         <p>
-          <strong>Main Hotline:</strong>
-          <a href="tel:617-222-3200">617-222-3200</a><br />
+          <strong>Main Hotline:</strong> <a href="tel:617-222-3200">617-222-3200</a><br />
           Toll Free: <a href="tel:800-392-6100">800-392-6100</a><br />
           TTY: <a href="tel:617-222-5146">617-222-5146</a>
         </p>
 
+        <h2>Do you want to learn more about the T?</h2>
+        <p>Our Travel Trainers at the <a href="https://www.mbta.com/accessibility/mbta-mobility-center">Mobility Center</a> are ready to assist. To learn how to ride the T safely and independently, plan your trip, use your mobile apps, and access other transit services, contact <a href="tel:617-337-2756">617-337-2756</a> or <a href="mailto:howtotravel@mbta.com">howtotravel@mbta.com</a>.</p>
+
         <h2>Sign up to receive MBTA accessibility emails</h2>
-        <p>
-          Join the MBTA's Department of System-wide Accessibility email list
-          to get periodic updates on the work we're doing and alerts for
-          upcoming meetings.
-        </p>
+        <p>Join the MBTA's Department of System-wide Accessibility email list to get periodic updates on the work we're doing and alerts for upcoming meetings.</p>
 
         <!-- Button -->
         <table border="0" cellspacing="0" cellpadding="0" role="presentation">

--- a/assets/intake_html/emails/approved_in_store_emails/approved-in-store-portuguese.html
+++ b/assets/intake_html/emails/approved_in_store_emails/approved-in-store-portuguese.html
@@ -132,33 +132,37 @@
         <h1>O <span class="formElementOnEditor" contenteditable="false" data-row-name="element276-hiddenTitle">Reduced Fare In Person Application: Long Program Name<em><small>(no title)</small></em></span> CharlieCard está pronto!</h1>
 
         <p>Pode apanhar o cartão na CharlieCard Store localizada na Downtown Crossing Station, no saguão subterrâneo entre as linhas Vermelha e Laranja:</p>
-
         <p>7 Chauncy St<br>
           Boston, MA 02111</p>
-
         <p>Para acessar a CharlieCard Store fora da estação, use o elevador acessível dentro do edifício na 101 Arch Street.</p>
-
         <p><a href="https://www.mbta.com/fares/charliecard-store">Horário de funcionamento da CharlieCard Store</a></p>
-
         <p>Não é necessário agendar para pegar o cartão.</p>
 
+        <h2>Sobre o cartão</h2>
+        <ul>
+          <li>Saiba <a href="https://www.mbta.com/fares/reduced">como usar o cartão</a>.</li>
+          <li>Se o cartão for danificado, perdido ou roubado, pode solicitar um cartão de substituição usando o aplicativo on-line ou ligando para o Atendimento ao Cliente pelo telefone 617-222-3200.</li>
+          <li>Se o cartão tiver sido renovado ou substituído, o passe mensal e o saldo do cartão antigo serão transferidos automaticamente para o novo cartão.</li>
+          <li><strong><span class="formElementOnEditor" contenteditable="false" data-row-name="element206-hiddenTitle">Generated Content: Card Duration Text<em><small>(no title)</small></em></span></strong></li>
+        </ul>
+
         <h2>Dúvidas?</h2>
-
         <p>Contate o <a href="https://www.mbta.com/customer-support">Atendimento ao cliente usando o formulário on-line</a> ou ligue para os números abaixo.</p>
-
         <p>
           Segunda a sexta: Das 6h30 às 20h00<br />
           Sábado a domingo: Das 8h00 às 16h00
         </p>
-        
         <p>
           <strong>Hotline principal: </strong><a href="tel:617-222-3200">617-222-3200</a><br />
           Gratuito: <a href="tel:800-392-6100">800-392-6100</a><br />
           TTY: <a href="tel:617-222-5146">617-222-5146</a>
         </p>
 
+        <h2>Gostaria de saber mais sobre o T?</h2>
+        <p>Nossos Travel Trainers (orientadores de viagens) no <a href="https://www.mbta.com/accessibility/mbta-mobility-center">Mobility Center</a> (Centro de Mobilidade) estão prontos para ajudar. Para saber como usar o T de forma segura e independente, planejar a sua viagem, usar os seus aplicativos móveis e ter acesso a outros serviços de trânsito, entre em contato pelo telefone <a href="tel:617-337-2756">617-337-2756</a> ou pelo e-mail <a href="mailto:howtotravel@mbta.com">howtotravel@mbta.com</a>.</p>
+
         <h2>Inscreva-se para receber e-mails de acessibilidade da MBTA</h2>
-        <p>Faça parte da lista de e-mails do Departamento de Acessibilidade da MBTA para obter atualizações periódicas sobre o trabalho que estamos realizando e alertas para as próximas reuniões.</p>
+        <p>Faça parte da lista de e-mails do Departamento de Acessibilidade da MBTA para obter atualizações periódicas sobre o trabalho que estamos realizando e alertas para as próximas reuniões.</p>  
 
         <!-- Button -->
         <table border="0" cellspacing="0" cellpadding="0" role="presentation">

--- a/assets/intake_html/emails/approved_in_store_emails/approved-in-store-spanish.html
+++ b/assets/intake_html/emails/approved_in_store_emails/approved-in-store-spanish.html
@@ -130,33 +130,35 @@
 
         <!-- Body copy -->
         <h1>¡Su <span class="formElementOnEditor" contenteditable="false" data-row-name="element276-hiddenTitle">Reduced Fare In Person Application: Long Program Name<em><small>(no title)</small></em></span> CharlieCard está lista!</h1>
-
         <p>Puede recoger su tarjeta en la CharlieCard Store, localizada en Downtown Crossing Station, en la explanada subterránea entre las líneas Red y Orange:</p>
-
         <p>7 Chauncy St<br>
           Boston, MA 02111</p>
-
         <p>A fin de tener acceso a la CharlieCard Store desde el exterior de la estación, use el elevador accesible dentro del edificio 101 Arch Street.</p>
-
         <p><a href="https://www.mbta.com/fares/charliecard-store">Ver horario de la CharlieCard Store</a></p>
-
         <p>No necesita agendar una cita para recoger la tarjeta.</p>
 
+        <h2>Información sobre su tarjeta</h2>
+        <ul>
+          <li>Aprenda <a href="https://www.mbta.com/fares/reduced">cómo usar la tarjeta</a>.</li>
+          <li>En caso de que la tarjeta se dañe, extravíe o se la roben, puede solicitar una tarjeta de reemplazo mediante la solicitud en línea o llamando a Soporte al cliente al número telefónico 617-222-3200.</li>
+          <li>Si la tarjeta fue una renovación o una reposición, el pase y el saldo mensuales de su tarjeta anterior se transferirán automáticamente a la nueva tarjeta.</li>
+          <li><strong><span class="formElementOnEditor" contenteditable="false" data-row-name="element206-hiddenTitle">Generated Content: Card Duration Text<em><small>(no title)</small></em></span></strong></li>
+        </ul>
+
         <h2>¿Preguntas?</h2>
-
         <p>Póngase en contacto con el <a href="https://www.mbta.com/customer-support">Servicio de atención al cliente a través de su formulario en línea</a> o llame al número que aparece a continuación.</p>
-
         <p>
           Lunes &ndash; viernes: 6:30 AM &ndash; 8 PM<br />
           Sábado &ndash; domingo: 8 AM &ndash; 4 PM
         </p>
-
         <p>
-          <strong>Línea directa principal: </strong>
-          <a href="tel:617-222-3200">617-222-3200</a><br />
+          <strong>Línea directa principal: </strong> <a href="tel:617-222-3200">617-222-3200</a><br />
           Llamada gratuita: <a href="tel:800-392-6100">800-392-6100</a><br />
           Teletipo TTY: <a href="tel:617-222-5146">617-222-5146</a>
         </p>
+
+        <h2>¿Quiere saber más sobre la T?</h2>
+        <p>Nuestros entrenadores de viaje en el <a href="https://www.mbta.com/accessibility/mbta-mobility-center">Mobility Center</a> (Centro de Movilidad) están dispuestos a ayudarle. Para saber cómo viajar en la T de forma segura e independiente, planificar su viaje, utilizar las aplicaciones móviles y acceder a otros servicios de tránsito, póngase en contacto con el <a href="tel:617-337-2756">617-337-2756</a> o escriba a <a href="mailto:howtotravel@mbta.com">howtotravel@mbta.com</a>.</p>
 
         <h2>Inscríbase para recibir correos electrónicos sobre la accesibilidad de la MBTA</h2>
         <p>Únase a la lista de correo electrónico del Departamento de Accesibilidad del Sistema de la MBTA para recibir actualizaciones periódicas sobre el trabajo que estamos realizando y alertas sobre las próximas reuniones.</p>

--- a/assets/intake_html/form_elements/intake-form-fields.html
+++ b/assets/intake_html/form_elements/intake-form-fields.html
@@ -313,3 +313,13 @@
 
 <!-- UNDELIVERABLE CARD NO CONTACT INFO | FORM ELEMENT 327 -->
 <p>The applicant did not provide their phone number or email address.</p>
+
+<!-- NAME CHANGE REVIEW APPLICATION CALLOUT | FORM ELEMENT 203 -->
+<div style="background-image: initial; background-attachment: initial; background-color: rgba(238, 238, 238, 1); border: 1px solid rgba(204, 204, 204, 1); padding: 5px 10px">
+    <span style="font-size: 11pt"><span style="line-height: 107%"><i class="fa fa-id-card-o" aria-hidden="true"></i> The applicant's name has changed since their last card.</span></span>
+</div>
+
+<!-- NAME CHANGE PREPARE CARD CALLOUT | FORM ELEMENT 204 -->
+<div style="background-image: initial; background-attachment: initial; background-color: rgba(238, 238, 238, 1); border: 1px solid rgba(204, 204, 204, 1); padding: 5px 10px">
+    <span style="font-size: 11pt"><span style="line-height: 107%"><i class="fa fa-id-card-o" aria-hidden="true"></i> The applicant's name has changed since their last card. <strong><span class="formElementOnEditor" contenteditable="false" data-row-name="element330-hiddenTitle">Personal Information: Name on previous card (require...<em><small>(no title)</small></em></span></strong> is recorded as the name on the prior card.</span></span>
+</div>

--- a/assets/senior_html/emails/approved_by_mail_emails/approved-by-mail-chinese-simplified.html
+++ b/assets/senior_html/emails/approved_by_mail_emails/approved-by-mail-chinese-simplified.html
@@ -141,39 +141,14 @@
 
           <!-- Body copy -->
           <h1>你的老年人查理卡正在发送过程中!</h1>
-          <p>
-            你的老年人查理卡将在3-5个工作日内通过USPS寄到你的邮寄地址。
-          </p>
+          <p>你的老年人查理卡将在3-5个工作日内通过USPS寄到你的邮寄地址。</p>
 
-          <h2>关于你的卡 </h2>
-
+          <h2>关于你的卡</h2>
           <ul>
-            <li>
-              你可以将你的<a href="https://www.mbta.com/fares/reduced/senior-charliecard">老年人查理卡</a>
-              用于：
-
-              <ul>
-                <li>
-                  <strong>50%的单程票价折扣</strong>巴士、地铁、高速巴士、通勤铁路和渡轮。
-                </li>
-                <li>
-                  <strong>30美元的月票</strong>或<strong>10美元的7天票</strong>，可无限次乘坐公共汽车、地铁、通勤铁路 1A 区和内港渡轮。
-                </li>
-                <li>
-                  高速巴士、通勤铁路和渡轮的<a href="https://www.mbta.com/fares/reduced#passes">折扣月票</a>。 
-                </li>
-              </ul>
-              
-            </li>
-            <li>
-              如果你的卡损坏、丢失或被盗，你可以使用网上申请或致打电话给客户支持 617-222-3200申请补发卡。 
-            </li>
-            <li>
-              如果你的卡是续期或更换卡，你的月票和旧卡中的余额将自动转移到你的新卡中。 
-            </li>
-            <li>
-              <strong>你的老年人查理卡的有效期是8年。</strong>
-            </li>
+            <li>了解<a href="https://www.mbta.com/fares/reduced/senior-charliecard">如何使用你的卡</a>。</li>
+            <li>如果你的卡损坏、丢失或被盗，你可以使用网上申请或致打电话给客户支持617-222-3200申请补发卡。</li>
+            <li>如果你的卡是续期或更换卡，你的月票和旧卡中的余额将自动转移到你的新卡中。</li>
+            <li><strong><span class="formElementOnEditor" contenteditable="false" data-row-name="element196-hiddenTitle">Generated Content: Card Duration Text<em><small>(no title)</small></em></span></strong></li>
           </ul>
 
           <h2>有问题吗?</h2>
@@ -192,11 +167,11 @@
             TTY: <a href="tel:617-222-5146">617-222-5146</a>
           </p>
 
-          <h2>注册以接收有关MBTA无障碍性的电子邮件</h2>
+          <h2>你是否想了解更多有关T的信息？</h2>
+          <p>我们的移动中心（<a href="https://www.mbta.com/accessibility/mbta-mobility-center">Mobility Center</a>）交通培训员随时准备为你提供帮助。要了解如何安全、独立地乘坐T、计划出行、使用移动应用程序以及获得其他交通服务，请联系<a href="tel:617-337-2756">617-337-2756</a>或<a href="mailto:howtotravel@mbta.com">howtotravel@mbta.com</a>。</p>  
 
-          <p>
-            加入MBTA的系统范围内无障碍性部门的电子邮件名单，以获取有关我们正在开展的工作的定期更新以及即将举行的会议通知。 
-          </p>
+          <h2>注册以接收有关MBTA无障碍性的电子邮件</h2>
+          <p>加入MBTA的系统范围内无障碍性部门的电子邮件名单，以获取有关我们正在开展的工作的定期更新以及即将举行的会议通知。</p>
 
           <!-- Button -->
           <table border="0" cellspacing="0" cellpadding="0" role="presentation">

--- a/assets/senior_html/emails/approved_by_mail_emails/approved-by-mail-chinese-traditional.html
+++ b/assets/senior_html/emails/approved_by_mail_emails/approved-by-mail-chinese-traditional.html
@@ -141,38 +141,14 @@
 
           <!-- Body copy -->
           <h1>你的老人查理卡正在發送過程中!</h1>
-          <p>
-            你的老人查理卡將在3-5個工作日內透過USPS寄到你的郵寄地址。 
-          </p>
+          <p>你的老人查理卡將在3-5個工作日內透過USPS寄到你的郵寄地址。</p>
 
           <h2>關於你的卡</h2>
-
           <ul>
-            <li>
-              你可以將你的<a href="https://www.mbta.com/fares/reduced/senior-charliecard">老人查理卡</a>用於:
-              
-              <ul>
-                <li>
-                  <strong>50% 的單程票價折扣</strong> 巴士、地鐵、高速巴士、通勤鐵路和渡輪。
-                </li>
-                <li>
-                  <strong>30 美元的月票</strong>或<strong>10美元的7天票</strong>，可無限次乘坐公共汽車、地鐵、通勤鐵路 1A 區和內港渡輪。
-                </li>
-                <li>
-                  高速巴士、通勤鐵路和渡輪的<a href="https://www.mbta.com/fares/reduced#passes">折扣月票</a>。
-                </li>
-              </ul>
-
-            </li>
-            <li>
-              如果你的卡損壞、丟失或被盜，你可以使用網上申請或致打電話給客戶幫助 617-222-3200申請補發卡。 
-            </li>
-            <li>
-              如果你的卡是續期或更換卡，你的月票和舊卡中的餘額將自動轉移到你的新卡中。
-            </li>
-            <li>
-              <strong>你的老人查理卡的有效期是8年。</strong>
-            </li>
+            <li>瞭解<a href="https://www.mbta.com/fares/reduced/senior-charliecard">如何使用你的卡</a>。</li>
+            <li>如果你的卡損壞、丟失或被盜，你可以使用網上申請或致打電話給客戶幫助 617-222-3200申請補發卡。</li>
+            <li>如果你的卡是續期或更換卡，你的月票和舊卡中的餘額將自動轉移到你的新卡中。</li>
+            <li><strong><span class="formElementOnEditor" contenteditable="false" data-row-name="element196-hiddenTitle">Generated Content: Card Duration Text<em><small>(no title)</small></em></span></strong></li>
           </ul>
 
           <h2>有問題嗎?</h2>
@@ -191,11 +167,12 @@
             TTY: <a href="tel:617-222-5146">617-222-5146</a>
           </p>
 
+          <h2>你是否想瞭解更多有關T的資訊？</h2>
+          <p>我們的移動中心（<a href="https://www.mbta.com/accessibility/mbta-mobility-center">Mobility Center</a>）交通訓練師隨時準備為你提供幫助。要瞭解如何安全、獨立乘坐T、計劃出行、使用移動應用程式以及獲得其他交通服務，請聯絡<a href="tel:617-337-2756">617-337-2756</a>或<a href="mailto:howtotravel@mbta.com">howtotravel@mbta.com</a>。</p>
+  
           <h2>註冊以接收有關MBTA無障礙的電子郵件</h2>
-
-          <p>
-            加入MBTA的系統範圍內無障礙部門的電子郵件名單，以獲取有關我們正在開展的工作的定期更新以及即將舉行的會議通知。
-          </p>
+          <p>加入MBTA的系統範圍內無障礙部門的電子郵件名單，以獲取有關我們正在開展的工作的定期更新以及即將舉行的會議通知。</p>
+  
 
           <!-- Button -->
           <table border="0" cellspacing="0" cellpadding="0" role="presentation">

--- a/assets/senior_html/emails/approved_by_mail_emails/approved-by-mail-english.html
+++ b/assets/senior_html/emails/approved_by_mail_emails/approved-by-mail-english.html
@@ -141,57 +141,18 @@
 
           <!-- Body copy -->
           <h1>Your Senior CharlieCard is on its way!</h1>
-          <p>
-            Your Senior CharlieCard will arrive via USPS in 3-5 business days to
-            your mailing address.
-          </p>
+          <p>Your Senior CharlieCard will arrive via USPS in 3-5 business days to your mailing address.</p>
 
           <h2>About your card</h2>
-
           <ul>
-            <li>
-              You can use your 
-              <a href="https://www.mbta.com/fares/reduced/senior-charliecard">Senior CharlieCard</a>
-              for:
-
-              <ul>
-                <li>
-                  <strong>50% off one-ways fares</strong> on bus, subway,
-                  Express Bus, Commuter Rail, and ferry.
-                </li>
-                <li>
-                  <strong>$30 monthly passes</strong> or <strong>$10 7-day passes</strong> for unlimited bus, subway,
-                  Commuter Rail Zone 1A, and Inner Harbor Ferry rides.
-                </li>
-                <li>
-                  <a href="https://www.mbta.com/fares/reduced#passes">Discounted monthly passes</a> for Express Bus, Commuter Rail, and ferry.
-                </li>
-              </ul>
-              
-            </li>
-            <li>
-              If your card is damaged, lost, or stolen, you can request a
-              replacement card using the online application or by calling
-              Customer Support at 617-222-3200.
-            </li>
-            <li>
-              If your card was a renewal or replacement, your monthly pass and
-              balance from your old card will be automatically transferred to
-              your new card.
-            </li>
-            <li>
-              <strong>Your Senior CharlieCard is valid for 8 years.</strong>
-            </li>
+            <li>Learn <a href="https://www.mbta.com/fares/reduced/senior-charliecard">how to use your card</a>.</li>
+            <li>If your card is damaged, lost, or stolen, you can request a replacement card using the online application or by calling Customer Support at 617-222-3200.</li>
+            <li>If your card was a renewal or replacement, your monthly pass and balance from your old card will be automatically transferred to your new card.</li>
+            <li><strong><span class="formElementOnEditor" contenteditable="false" data-row-name="element196-hiddenTitle">Generated Content: Card Duration Text<em><small>(no title)</small></em></span></strong></li>
           </ul>
 
           <h2>Questions?</h2>
-          <p>
-            Contact
-            <a href="https://www.mbta.com/customer-support"
-              >Customer Support using their online form</a
-            >
-            or call the numbers below.
-          </p>
+          <p>Contact <a href="https://www.mbta.com/customer-support">Customer Support using their online form</a> or call the numbers below.</p>
           <p>
             Monday &ndash; Friday: 6:30 AM &ndash; 8 PM<br />
             Saturday &ndash; Sunday: 8 AM &ndash; 4 PM
@@ -203,13 +164,11 @@
             TTY: <a href="tel:617-222-5146">617-222-5146</a>
           </p>
 
-          <h2>Sign up to receive MBTA accessibility emails</h2>
+          <h2>Do you want to learn more about the T?</h2>
+          <p>Our Travel Trainers at the <a href="https://www.mbta.com/accessibility/mbta-mobility-center">Mobility Center</a> are ready to assist. To learn how to ride the T safely and independently, plan your trip, use your mobile apps, and access other transit services, contact <a href="tel:617-337-2756">617-337-2756</a> or <a href="mailto:howtotravel@mbta.com">howtotravel@mbta.com</a>.</p>  
 
-          <p>
-            Join the MBTA's Department of System-wide Accessibility email list
-            to get periodic updates on the work we're doing and alerts for
-            upcoming meetings.
-          </p>
+          <h2>Sign up to receive MBTA accessibility emails</h2>
+          <p>Join the MBTA's Department of System-wide Accessibility email list to get periodic updates on the work we're doing and alerts for upcoming meetings.</p>  
 
           <!-- Button -->
           <table border="0" cellspacing="0" cellpadding="0" role="presentation">

--- a/assets/senior_html/emails/approved_by_mail_emails/approved-by-mail-portuguese.html
+++ b/assets/senior_html/emails/approved_by_mail_emails/approved-by-mail-portuguese.html
@@ -141,44 +141,18 @@
 
           <!-- Body copy -->
           <h1>O Senior CharlieCard está a caminho!</h1>
-          <p>
-            O cartão CharlieCard chegará pelo correio dentro de 3 a 5 dias úteis no endereço fornecido.
-          </p>
+          <p>O cartão CharlieCard chegará pelo correio dentro de 3 a 5 dias úteis no endereço fornecido.</p>
 
           <h2>Sobre o cartão</h2>
-
           <ul>
-            <li>
-              Pode usar o <a href="https://www.mbta.com/fares/reduced/senior-charliecard">Senior CharlieCard</a> para:
-              
-              <ul>
-                <li>
-                  <strong>50% de desconto em tarifas de ida</strong> em ônibus, metrô, ônibus expresso, trem suburbano e balsa.
-                </li>
-                <li>
-                  <strong>Passes mensais de $30</strong> ou <strong>passes de 7 dias de $10</strong> para ônibus, metrô, Commuter Rail Zone 1A e passeios de balsa do porto interno.
-                </li>
-                <li>
-                  <a href="https://www.mbta.com/fares/reduced#passes">Passes mensais com desconto</a> para ônibus expresso, trem suburbano e balsa.
-                </li>
-              </ul>
-
-            </li>
-            <li>
-              Se o cartão ficar danificado, for perdido ou roubado, solicite um outro cartão pelo modo on-line ou ligando para o Atendimento ao cliente no número 617-222-3200 .
-            </li>
-            <li>
-              Se o cartão foi renovado ou substituído, o passe mensal e o saldo do cartão antigo serão transferidos automaticamente para o novo cartão.
-            </li>
-            <li>
-              <strong>O Senior CharlieCard tem validade de 8 anos.</strong>
-            </li>
+            <li>Saiba <a href="https://www.mbta.com/fares/reduced/senior-charliecard">como usar o seu cartão</a>.</li>
+            <li>Se o cartão ficar danificado, for perdido ou roubado, solicite um outro cartão pelo modo on-line ou ligando para o Atendimento ao cliente no número 617-222-3200.</li>
+            <li>Se o cartão foi renovado ou substituído, o passe mensal e o saldo do cartão antigo serão transferidos automaticamente para o novo cartão.</li>
+            <li><strong><span class="formElementOnEditor" contenteditable="false" data-row-name="element196-hiddenTitle">Generated Content: Card Duration Text<em><small>(no title)</small></em></span></strong></li>
           </ul>
 
           <h2>Dúvidas?</h2>
-          <p>
-            Contate <a href="https://www.mbta.com/customer-support">Atendimento ao cliente usando o formulário on-line</a> ou ligue para os números abaixo.
-          </p>
+          <p>Contate <a href="https://www.mbta.com/customer-support">Atendimento ao cliente usando o formulário on-line</a> ou ligue para os números abaixo.</p>
           <p>
             Segunda a Sexta: 6h30 &ndash; 20h00<br />
             Sábado a Domingo: 8h00 &ndash; 16h00
@@ -189,11 +163,11 @@
             TTY: <a href="tel:617-222-5146">617-222-5146</a>
           </p>
 
+          <h2>Gostaria de saber mais sobre o T?</h2>
+          <p>Nossos Travel Trainers (orientadores de viagens) no <a href="https://www.mbta.com/accessibility/mbta-mobility-center">Mobility Center</a> (Centro de Mobilidade) estão prontos para ajudar. Para saber como usar o T de forma segura e independente, planejar a sua viagem, usar os seus aplicativos móveis e ter acesso a outros serviços de trânsito, entre em contato pelo telefone <a href="tel:617-337-2756">617-337-2756</a> ou pelo e-mail <a href="mailto:howtotravel@mbta.com">howtotravel@mbta.com</a>.</p>
+  
           <h2>Inscreva-se para receber e-mails de acessibilidade da MBTA</h2>
-
-          <p>
-            Faça parte da lista de e-mails do Departamento de Acessibilidade da MBTA para obter atualizações periódicas sobre o trabalho que estamos realizando e alertas para as próximas reuniões.
-          </p>
+          <p>Faça parte da lista de e-mails do Departamento de Acessibilidade da MBTA para obter atualizações periódicas sobre o trabalho que estamos realizando e alertas para as próximas reuniões.</p>  
 
           <!-- Button -->
           <table border="0" cellspacing="0" cellpadding="0" role="presentation">

--- a/assets/senior_html/emails/approved_by_mail_emails/approved-by-mail-spanish.html
+++ b/assets/senior_html/emails/approved_by_mail_emails/approved-by-mail-spanish.html
@@ -141,46 +141,18 @@
 
           <!-- Body copy -->
           <h1>¡Su CharlieCard para personas mayores está en camino!</h1>
-          <p>
-            Su CharlieCard para personas mayores llegará por USPS en 3-5 días laborables a su dirección postal.
-          </p>
+          <p>Su CharlieCard para personas mayores llegará por USPS en 3-5 días laborables a su dirección postal.</p>
 
           <h2>Sobre su tarjeta</h2>
-
           <ul>
-            <li>
-              Puede <a href="https://www.mbta.com/fares/reduced/senior-charliecard"
-                >utilizar su CharlieCard para personas mayores</a> para:
-                
-                <ul>
-                  <li>
-                    <strong>50% de descuento en tarifas de ida</strong> en autobús, metro, autobús exprés, tren de cercanías y ferry.
-                  </li>
-                  <li>
-                    <strong>Pases mensuales de $30</strong> o <strong>pases de $10 para 7 días</strong> para viajes ilimitados en autobús, metro, tren suburbano Zona 1A e Inner Harbor Ferry.
-                  </li>
-                  <li>
-                    <a href="https://www.mbta.com/fares/reduced#passes">Pases mensuales con descuento</a> para Express Bus, Commuter Rail y ferry.
-                  </li>
-                </ul>
-
-            </li>
-            <li>
-              Si su tarjeta se daña, se pierde o se la roban, puede solicitar una tarjeta de sustitución mediante la solicitud en línea o llamando al servicio de atención al cliente al 617-222-3200.
-            </li>
-            <li>
-              Si su tarjeta fue una renovación o un reemplazo, el pase mensual y el saldo de su antigua tarjeta serán transferidos automáticamente a su nueva tarjeta.
-            </li>
-            <li>
-              <strong>Su CharlieCard para personas mayores es válida durante 8 años.</strong>
-            </li>
+            <li>Aprenda <a href="https://www.mbta.com/fares/reduced/senior-charliecard">cómo usar la tarjeta</a>.</li>
+            <li>Si su tarjeta se daña, se pierde o se la roban, puede solicitar una tarjeta de reemplazo utilizando la solicitud en línea o llamando al servicio de atención al cliente al 617-222-3200.</li>
+            <li>Si su tarjeta era una renovación o un reemplazo, el pase mensual y el saldo de su antigua tarjeta se transferirán automáticamente a su nueva tarjeta.</li>
+            <li><strong><span class="formElementOnEditor" contenteditable="false" data-row-name="element196-hiddenTitle">Generated Content: Card Duration Text<em><small>(no title)</small></em></span></strong></li>
           </ul>
 
           <h2>¿Preguntas?</h2>
-          <p>
-            Póngase en contacto con <a href="https://www.mbta.com/customer-support">el servicio de atención al cliente a
-              través de su formulario en línea</a> o llame a los números que aparecen a continuación.
-          </p>  
+          <p>Póngase en contacto con <a href="https://www.mbta.com/customer-support">el servicio de atención al cliente a través de su formulario en línea</a> o llame a los números que aparecen a continuación.</p>  
           <p>
             Lunes &ndash; Viernes: 6:30 AM &ndash; 8 PM<br />
             Sábado &ndash; Domingo: 8 AM &ndash; 4 PM
@@ -191,10 +163,11 @@
             TTY: <a href="tel:617-222-5146">617-222-5146</a>
           </p>
 
+          <h2>¿Quiere saber más sobre la T?</h2>
+          <p>Nuestros entrenadores de viaje en el <a href="https://www.mbta.com/accessibility/mbta-mobility-center">Mobility Center</a> (Centro de Movilidad) están dispuestos a ayudarle. Para saber cómo viajar en la T de forma segura e independiente, planificar su viaje, utilizar las aplicaciones móviles y acceder a otros servicios de tránsito, póngase en contacto con el <a href="tel:617-337-2756">617-337-2756</a> o escriba a <a href="mailto:howtotravel@mbta.com">howtotravel@mbta.com</a>.</p>
+  
           <h2>Inscríbase para recibir correos electrónicos sobre la accesibilidad de la MBTA</h2>
-          <p>
-            Únase a la lista de correo electrónico del Departamento de Accesibilidad del Sistema de la MBTA para recibir actualizaciones periódicas sobre el trabajo que estamos realizando y alertas sobre las próximas reuniones.
-          </p>
+          <p>Únase a la lista de correo electrónico del Departamento de Accesibilidad del Sistema de la MBTA para recibir actualizaciones periódicas sobre el trabajo que estamos realizando y alertas sobre las próximas reuniones.</p>  
   
           <!-- Button -->
           <table border="0" cellspacing="0" cellpadding="0" role="presentation">

--- a/assets/senior_html/emails/approved_in_store_emails/approved-in-store-chinese-simplified.html
+++ b/assets/senior_html/emails/approved_in_store_emails/approved-in-store-chinese-simplified.html
@@ -129,20 +129,19 @@
                 <![endif]-->
 
         <!-- Body copy -->
-        <h1>你的老年人查理卡已经准备好！</h1>
-        <p>
-          前往位于Downtown Crossing车站红线和橙线之间地下大厅内的查理卡出售店：7 Chauncy Street, Boston, MA 02111。
-        </p>
-
-        <p>
-          如要从车站外进入查理卡出售店，请使用101 Arch Street大楼内的无障碍电梯。 
-        </p>
-
-        <p>
-          <a href="https://www.mbta.com/fares/charliecard-store">查看查理卡出售店营业时间</a>
-        </p>
-
+        <h1>你的老年人查理卡已经准备好!</h1>
+        <p>前往位于Downtown Crossing车站红线和橙线之间地下大厅内的查理卡出售店：7 Chauncy Street, Boston, MA 02111。</p>
+        <p>如要从车站外进入查理卡出售店，请使用101 Arch Street大楼内的无障碍电梯。</p>
+        <p><a href="https://www.mbta.com/fares/charliecard-store">查看查理卡出售店营业时间</a></p>
         <p>取卡无需预约。</p>
+
+        <h2>关于你的卡</h2>
+        <ul>
+          <li>了解<a href="https://www.mbta.com/fares/reduced/senior-charliecard">如何使用你的卡</a>。</li>
+          <li>如果你的卡损坏、丢失或被盗，你可以使用网上申请或致打电话给客户支持617-222-3200申请补发卡。</li>
+          <li>如果你的卡是续期或更换卡，你的月票和旧卡中的余额将自动转移到你的新卡中。</li>
+          <li><strong><span class="formElementOnEditor" contenteditable="false" data-row-name="element196-hiddenTitle">Generated Content: Card Duration Text<em><small>(no title)</small></em></span></strong></li>
+        </ul>
 
         <h2>有问题吗?</h2>
         <p>
@@ -160,11 +159,11 @@
           TTY: <a href="tel:617-222-5146">617-222-5146</a>
         </p>
 
-        <h2>注册以接收有关MBTA无障碍性的电子邮件</h2>
+        <h2>你是否想了解更多有关T的信息？</h2>
+        <p>我们的移动中心（<a href="https://www.mbta.com/accessibility/mbta-mobility-center">Mobility Center</a>）交通培训员随时准备为你提供帮助。要了解如何安全、独立地乘坐T、计划出行、使用移动应用程序以及获得其他交通服务，请联系<a href="tel:617-337-2756">617-337-2756</a>或<a href="mailto:howtotravel@mbta.com">howtotravel@mbta.com</a>。</p>  
 
-        <p>
-          加入MBTA的系统范围内无障碍性部门的电子邮件名单，以获取有关我们正在开展的工作的定期更新以及即将举行的会议通知。 
-        </p>
+        <h2>注册以接收有关MBTA无障碍性的电子邮件</h2>
+        <p>加入MBTA的系统范围内无障碍性部门的电子邮件名单，以获取有关我们正在开展的工作的定期更新以及即将举行的会议通知。</p>
 
         <!-- Button -->
         <table border="0" cellspacing="0" cellpadding="0" role="presentation">

--- a/assets/senior_html/emails/approved_in_store_emails/approved-in-store-chinese-traditional.html
+++ b/assets/senior_html/emails/approved_in_store_emails/approved-in-store-chinese-traditional.html
@@ -129,20 +129,20 @@
                 <![endif]-->
 
         <!-- Body copy -->
-        <h1>你的老人查理卡已經準備好！</h1>
-        <p>
-          前往位於Downtown Crossing車站紅線和橙線之間地下大廳內的查理卡出售店：7 Chauncy Street, Boston, MA 02111。
-        </p>
-
-        <p>
-          如要從車站外進入查理卡出售店，請使用101 Arch Street大樓內的無障礙電梯。
-        </p>
-
-        <p>
-          <a href="https://www.mbta.com/fares/charliecard-store">查看查理卡出售店的營業時間</a>
-        </p>
+        <h1>你的老人查理卡已經準備好!</h1>
+        <p>前往位於Downtown Crossing車站紅線和橙線之間地下大廳內的查理卡出售店：7 Chauncy Street, Boston, MA 02111。</p>
+        <p>如要從車站外進入查理卡出售店，請使用101 Arch Street大樓內的無障礙電梯。</p>
+        <p><a href="https://www.mbta.com/fares/charliecard-store">查看查理卡出售店的營業時間</a></p>
 
         <p>取卡無需預約。</p>
+
+        <h2>關於你的卡</h2>
+        <ul>
+          <li>瞭解<a href="https://www.mbta.com/fares/reduced/senior-charliecard">如何使用你的卡</a>。</li>
+          <li>如果你的卡損壞、丟失或被盜，你可以使用網上申請或致打電話給客戶幫助 617-222-3200申請補發卡。</li>
+          <li>如果你的卡是續期或更換卡，你的月票和舊卡中的餘額將自動轉移到你的新卡中。</li>
+          <li><strong><span class="formElementOnEditor" contenteditable="false" data-row-name="element196-hiddenTitle">Generated Content: Card Duration Text<em><small>(no title)</small></em></span></strong></li>
+        </ul>
 
         <h2>有問題嗎?</h2>
         <p>
@@ -160,11 +160,11 @@
           TTY: <a href="tel:617-222-5146">617-222-5146</a>
         </p>
 
-        <h2>註冊以接收有關MBTA無障礙的電子郵件</h2>
+        <h2>你是否想瞭解更多有關T的資訊？</h2>
+        <p>我們的移動中心（<a href="https://www.mbta.com/accessibility/mbta-mobility-center">Mobility Center</a>）交通訓練師隨時準備為你提供幫助。要瞭解如何安全、獨立乘坐T、計劃出行、使用移動應用程式以及獲得其他交通服務，請聯絡<a href="tel:617-337-2756">617-337-2756</a>或<a href="mailto:howtotravel@mbta.com">howtotravel@mbta.com</a>。</p>
 
-        <p>
-          加入MBTA的系統範圍內無障礙部門的電子郵件名單，以獲取有關我們正在開展的工作的定期更新以及即將舉行的會議通知。
-        </p>
+        <h2>註冊以接收有關MBTA無障礙的電子郵件</h2>
+        <p>加入MBTA的系統範圍內無障礙部門的電子郵件名單，以獲取有關我們正在開展的工作的定期更新以及即將舉行的會議通知。</p>
 
         <!-- Button -->
         <table border="0" cellspacing="0" cellpadding="0" role="presentation">

--- a/assets/senior_html/emails/approved_in_store_emails/approved-in-store-english.html
+++ b/assets/senior_html/emails/approved_in_store_emails/approved-in-store-english.html
@@ -130,29 +130,21 @@
 
         <!-- Body copy -->
         <h1>Your Senior CharlieCard is ready!</h1>
-        <p>
-          Visit the CharlieCard Store, located at Downtown Crossing Station,
-          on the underground concourse between the Red and Orange lines: 7
-          Chauncy Street Boston, MA 02111.
-        </p>
-
-        <p>
-          To access the CharlieCard Store from outside the station, use the
-          accessible elevator inside the 101 Arch Street building.
-        </p>
-
-        <p>
-          <a href="https://www.mbta.com/fares/charliecard-store">View CharlieCard Store hours</a>
-        </p>
-
+        <p>Visit the CharlieCard Store, located at Downtown Crossing Station, on the underground concourse between the Red and Orange lines: 7 Chauncy St Boston, MA 02111.</p>
+        <p>To access the CharlieCard Store from outside the station, use the accessible elevator inside the 101 Arch Street building.</p>
+        <p><a href="https://www.mbta.com/fares/charliecard-store">View CharlieCard Store hours</a></p>
         <p>No appointment is needed to pick up your card.</p>
 
+        <h2>About your card</h2>
+        <ul>
+          <li>Learn <a href="https://www.mbta.com/fares/reduced/senior-charliecard">how to use your card</a>.</li>
+          <li>If your card is damaged, lost, or stolen, you can request a replacement card using the online application or by calling Customer Support at 617-222-3200.</li>
+          <li>If your card was a renewal or replacement, your monthly pass and balance from your old card will be automatically transferred to your new card.</li>
+          <li><strong><span class="formElementOnEditor" contenteditable="false" data-row-name="element196-hiddenTitle">Generated Content: Card Duration Text<em><small>(no title)</small></em></span></strong></li>
+        </ul>
+
         <h2>Questions?</h2>
-        <p>
-          Contact
-          <a href="https://www.mbta.com/customer-support">Customer Support using their online form</a>
-          or call the numbers below.
-        </p>
+        <p>Contact <a href="https://www.mbta.com/customer-support">Customer Support using their online form</a> or call the numbers below.</p>
         <p>
           Monday &ndash; Friday: 6:30 AM &ndash; 8 PM<br />
           Saturday &ndash; Sunday: 8 AM &ndash; 4 PM
@@ -164,12 +156,11 @@
           TTY: <a href="tel:617-222-5146">617-222-5146</a>
         </p>
 
+        <h2>Do you want to learn more about the T?</h2>
+        <p>Our Travel Trainers at the <a href="https://www.mbta.com/accessibility/mbta-mobility-center">Mobility Center</a> are ready to assist. To learn how to ride the T safely and independently, plan your trip, use your mobile apps, and access other transit services, contact <a href="tel:617-337-2756">617-337-2756</a> or <a href="mailto:howtotravel@mbta.com">howtotravel@mbta.com</a>.</p>
+
         <h2>Sign up to receive MBTA accessibility emails</h2>
-        <p>
-          Join the MBTA's Department of System-wide Accessibility email list
-          to get periodic updates on the work we're doing and alerts for
-          upcoming meetings.
-        </p>
+        <p>Join the MBTA's Department of System-wide Accessibility email list to get periodic updates on the work we're doing and alerts for upcoming meetings.</p>
 
         <!-- Button -->
         <table border="0" cellspacing="0" cellpadding="0" role="presentation">
@@ -202,8 +193,7 @@
     <!-- Footer -->
     <footer>
       <p style="margin-top: 24px">
-        <a href="https://www.mbta.com/policies/privacy-policy#4.4" target="_blank" style="color: #165c96">Privacy
-          policy</a>
+        <a href="https://www.mbta.com/policies/privacy-policy#4.4" target="_blank" style="color: #165c96">Privacy policy</a>
       </p>
     </footer>
   </div>

--- a/assets/senior_html/emails/approved_in_store_emails/approved-in-store-portuguese.html
+++ b/assets/senior_html/emails/approved_in_store_emails/approved-in-store-portuguese.html
@@ -131,12 +131,17 @@
         <!-- Body copy -->
         <h1>O Senior CharlieCard está pronto!</h1>
         <p>Visite a CharlieCard Store, localizada na Downtown Crossing Station, no saguão subterrâneo entre as linhas Vermelha e Laranja:7 Chauncy Street, Boston, MA 02111.</p>
-
         <p>Para acessar a CharlieCard Store de fora da estação, use o elevador acessível dentro do edifício em 101 Arch Street.</p>
-
         <p><a href="https://www.mbta.com/fares/charliecard-store">Visualizar horário de funcionamento da CharlieCard Store</a></p>
-
         <p>Não é necessário agendar um horário para retirar o cartão.</p>
+
+        <h2>Sobre o cartão</h2>
+        <ul>
+          <li>Saiba <a href="https://www.mbta.com/fares/reduced/senior-charliecard">como usar o seu cartão</a>.</li>
+          <li>Se o cartão ficar danificado, for perdido ou roubado, solicite um outro cartão pelo modo on-line ou ligando para o Atendimento ao cliente no número 617-222-3200.</li>
+          <li>Se o cartão foi renovado ou substituído, o passe mensal e o saldo do cartão antigo serão transferidos automaticamente para o novo cartão.</li>
+          <li><strong><span class="formElementOnEditor" contenteditable="false" data-row-name="element196-hiddenTitle">Generated Content: Card Duration Text<em><small>(no title)</small></em></span></strong></li>
+        </ul>
 
         <h2>Dúvidas?</h2>
         <p>Contate <a href="https://www.mbta.com/customer-support">Atendimento ao cliente usando o formulário on-line</a> ou ligue para os números abaixo.</p>
@@ -150,11 +155,11 @@
           TTY: <a href="tel:617-222-5146">617-222-5146</a>
         </p>
 
-        <h2>Inscreva-se para receber e-mails de acessibilidade da MBTA</h2>
+        <h2>Gostaria de saber mais sobre o T?</h2>
+        <p>Nossos Travel Trainers (orientadores de viagens) no <a href="https://www.mbta.com/accessibility/mbta-mobility-center">Mobility Center</a> (Centro de Mobilidade) estão prontos para ajudar. Para saber como usar o T de forma segura e independente, planejar a sua viagem, usar os seus aplicativos móveis e ter acesso a outros serviços de trânsito, entre em contato pelo telefone <a href="tel:617-337-2756">617-337-2756</a> ou pelo e-mail <a href="mailto:howtotravel@mbta.com">howtotravel@mbta.com</a>.</p>
 
-        <p>
-          Faça parte da lista de e-mails do Departamento de Acessibilidade da MBTA para obter atualizações periódicas sobre o trabalho que estamos realizando e alertas para as próximas reuniões.
-        </p>
+        <h2>Inscreva-se para receber e-mails de acessibilidade da MBTA</h2>
+        <p>Faça parte da lista de e-mails do Departamento de Acessibilidade da MBTA para obter atualizações periódicas sobre o trabalho que estamos realizando e alertas para as próximas reuniões.</p>
 
         <!-- Button -->
         <table border="0" cellspacing="0" cellpadding="0" role="presentation">

--- a/assets/senior_html/emails/approved_in_store_emails/approved-in-store-spanish.html
+++ b/assets/senior_html/emails/approved_in_store_emails/approved-in-store-spanish.html
@@ -130,25 +130,21 @@
 
         <!-- Body copy -->
         <h1>¡Su CharlieCard para personas mayores está lista!</h1>
-        <p>
-          Visite la Tienda CharlieCard, situada en la estación Downtown Crossing, en el vestíbulo subterráneo entre las líneas Roja y Naranja: 7 Chauncy Street, Boston, MA 02111.
-        </p>
-
-        <p>
-          Para acceder a la Tienda CharlieCard desde el exterior de la estación, utilice el ascensor accesible que se encuentra en el interior del edificio de la calle Arch 101.
-        </p>
-
-        <p>
-          <a href="https://www.mbta.com/fares/charliecard-store">Ver el horario de la Tienda CharlieCard</a>
-        </p>
-
+        <p>Visite la Tienda CharlieCard, situada en la estación Downtown Crossing, en el vestíbulo subterráneo entre las líneas Roja y Naranja: 7 Chauncy Street, Boston, MA 02111.</p>
+        <p>Para acceder a la Tienda CharlieCard desde el exterior de la estación, utilice el ascensor accesible que se encuentra en el interior del edificio de la calle Arch 101.</p>
+        <p><a href="https://www.mbta.com/fares/charliecard-store">Ver el horario de la Tienda CharlieCard</a></p>
         <p>No es necesario pedir cita para recoger su tarjeta.</p>
 
+        <h2>Sobre su tarjeta</h2>
+        <ul>
+          <li>Aprenda <a href="https://www.mbta.com/fares/reduced/senior-charliecard">cómo usar la tarjeta</a>.</li>
+          <li>Si su tarjeta se daña, se pierde o se la roban, puede solicitar una tarjeta de reemplazo utilizando la solicitud en línea o llamando al servicio de atención al cliente al 617-222-3200.</li>
+          <li>Si su tarjeta era una renovación o un reemplazo, el pase mensual y el saldo de su antigua tarjeta se transferirán automáticamente a su nueva tarjeta.</li>
+          <li><strong><span class="formElementOnEditor" contenteditable="false" data-row-name="element196-hiddenTitle">Generated Content: Card Duration Text<em><small>(no title)</small></em></span></strong></li>
+        </ul>
+
         <h2>¿Preguntas?</h2>
-        <p>
-          Póngase en contacto con <a href="https://www.mbta.com/customer-support">el servicio de atención al cliente a
-            través de su formulario en línea</a> o llame a los números que aparecen a continuación.
-        </p>  
+        <p>Póngase en contacto con <a href="https://www.mbta.com/customer-support">el servicio de atención al cliente a través de su formulario en línea</a> o llame a los números que aparecen a continuación.</p>
         <p>
           Lunes &ndash; Viernes: 6:30 AM &ndash; 8 PM<br />
           Sábado &ndash; Domingo: 8 AM &ndash; 4 PM
@@ -159,10 +155,11 @@
           TTY: <a href="tel:617-222-5146">617-222-5146</a>
         </p>
 
+        <h2>¿Quiere saber más sobre la T?</h2>
+        <p>Nuestros entrenadores de viaje en el <a href="https://www.mbta.com/accessibility/mbta-mobility-center">Mobility Center</a> (Centro de Movilidad) están dispuestos a ayudarle. Para saber cómo viajar en la T de forma segura e independiente, planificar su viaje, utilizar las aplicaciones móviles y acceder a otros servicios de tránsito, póngase en contacto con el <a href="tel:617-337-2756">617-337-2756</a> o escriba a <a href="mailto:howtotravel@mbta.com">howtotravel@mbta.com</a>.</p>
+
         <h2>Inscríbase para recibir correos electrónicos sobre la accesibilidad de la MBTA</h2>
-        <p>
-          Únase a la lista de correo electrónico del Departamento de Accesibilidad del Sistema de la MBTA para recibir actualizaciones periódicas sobre el trabajo que estamos realizando y alertas sobre las próximas reuniones.
-        </p>
+        <p>Únase a la lista de correo electrónico del Departamento de Accesibilidad del Sistema de la MBTA para recibir actualizaciones periódicas sobre el trabajo que estamos realizando y alertas sobre las próximas reuniones.</p>
 
         <!-- Button -->
         <table border="0" cellspacing="0" cellpadding="0" role="presentation">

--- a/assets/senior_html/pdfs/in_store_slips/in-store-slip-chinese-simplified.html
+++ b/assets/senior_html/pdfs/in_store_slips/in-store-slip-chinese-simplified.html
@@ -1,12 +1,9 @@
 <div style="margin:0; padding: 0"><img src="https://mbta.prod.simpligov.com/prod/portal/file/51d7628117ce4c0c9cb0000188390b62.png?t=1633355953036" style="width: 335.4px; height: 62.4px; margin-left: 8px; margin-top: 6px" />
     <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">MBTA Senior CharlieCard</p>
-    
     <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">Order date (订购日期): <span class="formElementOnEditor" contenteditable="false" data-row-name="element130-hiddenTitle">Prepare Card: Date card prepared<em><small>(no title)</small></em></span></p>
     
-    <p style="font-size: 16px; font-family: Arial; margin: 43px 0 2px 62px; padding: 0;"><span class="formElementOnEditor" contenteditable="false" data-row-name="element12-hiddenTitle">Personal Information: First name (required)<em><small>(no title)</small></em></span>&nbsp;<span class="formElementOnEditor" contenteditable="false" data-row-name="element13-hiddenTitle">Personal Information: Last name (required)<em><small>(no title)</small></em></span></p>
-    
+    <p style="font-size: 16px; font-family: Arial; margin: 43px 0 2px 62px; padding: 0;"><span class="formElementOnEditor" contenteditable="false" data-row-name="element12-hiddenTitle">Personal Information: First name (required)<em><small>(no title)</small></em></span>&nbsp;<span class="formElementOnEditor" contenteditable="false" data-row-name="element13-hiddenTitle">Personal Information: Last name (required)<em><small>(no title)</small></em></span></p> 
     <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;">7 Chauncy Street</p>
-    
     <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;">Boston, MA 02111</p>
     
     <hr style="margin: 56px 0 0 0; padding: 0;" />
@@ -23,6 +20,16 @@
     <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;"><strong>储存价值转账</strong><br />
     <span class="formElementOnEditor" contenteditable="false" data-row-name="element110-hiddenTitle">Prepare Card: Stored value transfer (require...<em><small>(no title)</small></em></span></p>
     
+    <p>&nbsp;</p>
+
+    <h2 style="font-size: 20.8px; font-family: Arial; font-weight: 700; margin-left: 16px; padding: 0;">
+        <strong>卡片时长</strong>
+    </h2>
+
+    <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;">
+        <span class="formElementOnEditor" contenteditable="false" data-row-name="element196-hiddenTitle">Generated Content: Card Duration Text<em><small>(no title)</small></em></span>
+    </p>
+
     <p>&nbsp;</p>
     
     <h2 style="font-size: 20.8px; font-family: Arial; font-weight: 700; margin-left: 16px; padding: 0;">

--- a/assets/senior_html/pdfs/in_store_slips/in-store-slip-chinese-traditional.html
+++ b/assets/senior_html/pdfs/in_store_slips/in-store-slip-chinese-traditional.html
@@ -1,12 +1,9 @@
 <div style="margin:0; padding: 0"><img src="https://mbta.prod.simpligov.com/prod/portal/file/51d7628117ce4c0c9cb0000188390b62.png?t=1633355953036" style="width: 335.4px; height: 62.4px; margin-left: 8px; margin-top: 6px" />
     <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">MBTA Senior CharlieCard</p>
-    
     <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">Order date (訂購日期): <span class="formElementOnEditor" contenteditable="false" data-row-name="element130-hiddenTitle">Prepare Card: Date card prepared<em><small>(no title)</small></em></span></p>
     
     <p style="font-size: 16px; font-family: Arial; margin: 43px 0 2px 62px; padding: 0;"><span class="formElementOnEditor" contenteditable="false" data-row-name="element12-hiddenTitle">Personal Information: First name (required)<em><small>(no title)</small></em></span>&nbsp;<span class="formElementOnEditor" contenteditable="false" data-row-name="element13-hiddenTitle">Personal Information: Last name (required)<em><small>(no title)</small></em></span></p>
-    
-    <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;">7 Chauncy Street</p>
-    
+    <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;">7 Chauncy Street</p>  
     <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;">Boston, MA 02111</p>
     
     <hr style="margin: 56px 0 0 0; padding: 0;" />
@@ -23,6 +20,16 @@
     <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;"><strong>儲存價值轉賬</strong><br />
     <span class="formElementOnEditor" contenteditable="false" data-row-name="element110-hiddenTitle">Prepare Card: Stored value transfer (require...<em><small>(no title)</small></em></span></p>
     
+    <p>&nbsp;</p>
+
+    <h2 style="font-size: 20.8px; font-family: Arial; font-weight: 700; margin-left: 16px; padding: 0;">
+        <strong>卡有效期 </strong>
+    </h2>
+
+    <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;">
+        <span class="formElementOnEditor" contenteditable="false" data-row-name="element196-hiddenTitle">Generated Content: Card Duration Text<em><small>(no title)</small></em></span>
+    </p>
+
     <p>&nbsp;</p>
     
     <h2 style="font-size: 20.8px; font-family: Arial; font-weight: 700; margin-left: 16px; padding: 0;">

--- a/assets/senior_html/pdfs/in_store_slips/in-store-slip-english.html
+++ b/assets/senior_html/pdfs/in_store_slips/in-store-slip-english.html
@@ -1,31 +1,17 @@
-<div style="margin:0; padding: 0"><img
-        src="https://mbta.prod.simpligov.com/prod/portal/file/51d7628117ce4c0c9cb0000188390b62.png?t=1633355953036"
-        style="width: 335.4px; height: 62.4px; margin-left: 8px; margin-top: 6px" />
-    <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">MBTA Senior CharlieCard
-    </p>
-
-    <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">Order date: <span
-            class="formElementOnEditor" contenteditable="false" data-row-name="element130-hiddenTitle">Prepare Card:
-            Date card prepared<em><small>(no title)</small></em></span></p>
-
-    <p style="font-size: 16px; font-family: Arial; margin: 43px 0 2px 62px; padding: 0;"><span
-            class="formElementOnEditor" contenteditable="false" data-row-name="element12-hiddenTitle">Personal
-            Information: First name (required)<em><small>(no title)</small></em></span>&nbsp;<span
-            class="formElementOnEditor" contenteditable="false" data-row-name="element13-hiddenTitle">Personal
-            Information: Last name (required)<em><small>(no title)</small></em></span></p>
-
-    <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;">7 Chauncy Street</p>
-
+<div style="margin:0; padding: 0"><img src="https://mbta.prod.simpligov.com/prod/portal/file/51d7628117ce4c0c9cb0000188390b62.png?t=1633355953036" style="width: 335.4px; height: 62.4px; margin-left: 8px; margin-top: 6px" />
+    <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">MBTA Senior CharlieCard</p>
+    <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">Order date: <span class="formElementOnEditor" contenteditable="false" data-row-name="element130-hiddenTitle">Prepare Card: Date card prepared<em><small>(no title)</small></em></span></p>
+    
+    <p style="font-size: 16px; font-family: Arial; margin: 43px 0 2px 62px; padding: 0;"><span class="formElementOnEditor" contenteditable="false" data-row-name="element12-hiddenTitle">Personal Information: First name (required)<em><small>(no title)</small></em></span>&nbsp;<span class="formElementOnEditor" contenteditable="false" data-row-name="element13-hiddenTitle">Personal Information: Last name (required)<em><small>(no title)</small></em></span></p>
+    <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;">7 Chauncy Street</p>  
     <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;">Boston, MA 02111</p>
-
+    
     <hr style="margin: 56px 0 0 0; padding: 0;" />
-    <h1
-        style="font-size: 27.3px; font-family: Arial; font-weight: 700; margin-top: 48px; margin-left: 16px; padding: 0;">
+    <h1 style="font-size: 27.3px; font-family: Arial; font-weight: 700; margin-top: 48px; margin-left: 16px; padding: 0;">
         Your Senior CharlieCard</h1>
 
     <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;"><strong>Serial number</strong><br />
-        <span class="formElementOnEditor" contenteditable="false" data-row-name="element109-hiddenTitle">Prepare Card:
-            New serial card number (requir...<em><small>(no title)</small></em></span>
+        <span class="formElementOnEditor" contenteditable="false" data-row-name="element109-hiddenTitle">Prepare Card: New serial card number (requir...<em><small>(no title)</small></em></span>
     </p>
 
     <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;">
@@ -33,14 +19,22 @@
 
     <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;">
         <strong>Monthly transfer</strong><br />
-        <span class="formElementOnEditor" contenteditable="false" data-row-name="element111-hiddenTitle">Prepare Card:
-            Monthly transfer? (required)<em><small>(no title)</small></em></span>
+        <span class="formElementOnEditor" contenteditable="false" data-row-name="element111-hiddenTitle">Prepare Card: Monthly transfer? (required)<em><small>(no title)</small></em></span>
     </p>
 
     <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;">
         <strong>Stored value transfer</strong><br />
-        <span class="formElementOnEditor" contenteditable="false" data-row-name="element110-hiddenTitle">Prepare Card:
-            Stored value transfer (require...<em><small>(no title)</small></em></span>
+        <span class="formElementOnEditor" contenteditable="false" data-row-name="element110-hiddenTitle">Prepare Card: Stored value transfer (require...<em><small>(no title)</small></em></span>
+    </p>
+
+    <p>&nbsp;</p>
+
+    <h2 style="font-size: 20.8px; font-family: Arial; font-weight: 700; margin-left: 16px; padding: 0;">
+        <strong>Card duration</strong>
+    </h2>
+
+    <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;">
+        <span class="formElementOnEditor" contenteditable="false" data-row-name="element196-hiddenTitle">Generated Content: Card Duration Text<em><small>(no title)</small></em></span>
     </p>
 
     <p>&nbsp;</p>
@@ -48,8 +42,7 @@
     <h2 style="font-size: 20.8px; font-family: Arial; font-weight: 700; margin-left: 16px; padding: 0;">
         <strong>Questions?</strong></h2>
 
-    <p style="font-size: 16px; font-family: Arial; font-weight: 700; margin-left: 16px; padding: 0;">Contact Customer
-        Support</p>
+    <p style="font-size: 16px; font-family: Arial; font-weight: 700; margin-left: 16px; padding: 0;">Contact Customer Support</p>
 
     <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;">
         Monday &ndash; Friday: 6:30 AM &ndash; 8 PM<br />

--- a/assets/senior_html/pdfs/in_store_slips/in-store-slip-portuguese.html
+++ b/assets/senior_html/pdfs/in_store_slips/in-store-slip-portuguese.html
@@ -1,46 +1,37 @@
-<div style="margin:0; padding: 0"><img
-        src="https://mbta.prod.simpligov.com/prod/portal/file/51d7628117ce4c0c9cb0000188390b62.png?t=1633355953036"
-        style="width: 335.4px; height: 62.4px; margin-left: 8px; margin-top: 6px" />
-    <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">MBTA Senior CharlieCard
-    </p>
-
-    <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">Data do pedido: <span
-            class="formElementOnEditor" contenteditable="false" data-row-name="element130-hiddenTitle">Prepare Card:
-            Date card prepared<em><small>(no title)</small></em></span></p>
-
-    <p style="font-size: 16px; font-family: Arial; margin: 43px 0 2px 62px; padding: 0;"><span
-            class="formElementOnEditor" contenteditable="false" data-row-name="element12-hiddenTitle">Personal
-            Information: First name (required)<em><small>(no title)</small></em></span>&nbsp;<span
-            class="formElementOnEditor" contenteditable="false" data-row-name="element13-hiddenTitle">Personal
-            Information: Last name (required)<em><small>(no title)</small></em></span></p>
-
-    <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;">7 Chauncy Street</p>
-
+<div style="margin:0; padding: 0"><img src="https://mbta.prod.simpligov.com/prod/portal/file/51d7628117ce4c0c9cb0000188390b62.png?t=1633355953036" style="width: 335.4px; height: 62.4px; margin-left: 8px; margin-top: 6px" />
+    <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">MBTA Senior CharlieCard</p>
+    <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">Order date (data do pedido): <span class="formElementOnEditor" contenteditable="false" data-row-name="element130-hiddenTitle">Prepare Card: Date card prepared<em><small>(no title)</small></em></span></p>
+    
+    <p style="font-size: 16px; font-family: Arial; margin: 43px 0 2px 62px; padding: 0;"><span class="formElementOnEditor" contenteditable="false" data-row-name="element12-hiddenTitle">Personal Information: First name (required)<em><small>(no title)</small></em></span>&nbsp;<span class="formElementOnEditor" contenteditable="false" data-row-name="element13-hiddenTitle">Personal Information: Last name (required)<em><small>(no title)</small></em></span></p>
+    <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;">7 Chauncy Street</p>  
     <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;">Boston, MA 02111</p>
-
+    
     <hr style="margin: 56px 0 0 0; padding: 0;" />
     <h1 style="font-size:27.3px; font-family: Arial; font-weight: 700; margin-top: 48px; margin-left: 16px; padding: 0;">
         O novo Senior CharlieCard</h1>
 
-    <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;"><strong>Número de
-            série</strong><br />
-        <span class="formElementOnEditor" contenteditable="false" data-row-name="element109-hiddenTitle">Prepare Card:
-            New serial card number (requir...<em><small>(no title)</small></em></span>
+    <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;"><strong>Número de série</strong><br />
+        <span class="formElementOnEditor" contenteditable="false" data-row-name="element109-hiddenTitle">Prepare Card: New serial card number (requir...<em><small>(no title)</small></em></span>
     </p>
 
-    <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;">Precisará desse número se o cartão
-        for perdido, roubado ou danificado.</p>
+    <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;">Precisará desse número se o cartão for perdido, roubado ou danificado.</p>
 
-    <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;"><strong>Transferência
-            mensal</strong><br />
-        <span class="formElementOnEditor" contenteditable="false" data-row-name="element111-hiddenTitle">Prepare Card:
-            Monthly transfer? (required)<em><small>(no title)</small></em></span>
+    <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;"><strong>Transferência mensal</strong><br />
+        <span class="formElementOnEditor" contenteditable="false" data-row-name="element111-hiddenTitle">Prepare Card: Monthly transfer? (required)<em><small>(no title)</small></em></span>
     </p>
 
-    <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;"><strong>Transferência de valor
-            depositado</strong><br />
-        <span class="formElementOnEditor" contenteditable="false" data-row-name="element110-hiddenTitle">Prepare Card:
-            Stored value transfer (require...<em><small>(no title)</small></em></span>
+    <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;"><strong>Transferência de valor depositado</strong><br />
+        <span class="formElementOnEditor" contenteditable="false" data-row-name="element110-hiddenTitle">Prepare Card: Stored value transfer (require...<em><small>(no title)</small></em></span>
+    </p>
+
+    <p>&nbsp;</p>
+
+    <h2 style="font-size: 20.8px; font-family: Arial; font-weight: 700; margin-left: 16px; padding: 0;">
+        <strong>Duração do cartão</strong>
+    </h2>
+
+    <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;">
+        <span class="formElementOnEditor" contenteditable="false" data-row-name="element196-hiddenTitle">Generated Content: Card Duration Text<em><small>(no title)</small></em></span>
     </p>
 
     <p>&nbsp;</p>

--- a/assets/senior_html/pdfs/in_store_slips/in-store-slip-spanish.html
+++ b/assets/senior_html/pdfs/in_store_slips/in-store-slip-spanish.html
@@ -1,46 +1,39 @@
-<div style="margin:0; padding: 0"><img
-        src="https://mbta.prod.simpligov.com/prod/portal/file/51d7628117ce4c0c9cb0000188390b62.png?t=1633355953036"
-        style="width: 335.4px; height: 62.4px; margin-left: 8px; margin-top: 6px" />
+<div style="margin:0; padding: 0"><img src="https://mbta.prod.simpligov.com/prod/portal/file/51d7628117ce4c0c9cb0000188390b62.png?t=1633355953036" style="width: 335.4px; height: 62.4px; margin-left: 8px; margin-top: 6px" />
     <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">MBTA Senior CharlieCard</p>
-
-    <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">Order date (Fecha del pedido): <span
-            class="formElementOnEditor" contenteditable="false" data-row-name="element130-hiddenTitle">Prepare Card:
-            Date card prepared<em><small>(no title)</small></em></span></p>
-
-    <p style="font-size: 16px; font-family: Arial; margin: 43px 0 2px 62px; padding: 0;"><span
-            class="formElementOnEditor" contenteditable="false" data-row-name="element12-hiddenTitle">Personal
-            Information: First name (required)<em><small>(no title)</small></em></span>&nbsp;<span
-            class="formElementOnEditor" contenteditable="false" data-row-name="element13-hiddenTitle">Personal
-            Information: Last name (required)<em><small>(no title)</small></em></span></p>
-
-    <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;">7 Chauncy Street
-    </p>
-
-    <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;">Boston, MA 02111
-    </p>
-
+    <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">Order date (fecha del pedido): <span class="formElementOnEditor" contenteditable="false" data-row-name="element130-hiddenTitle">Prepare Card: Date card prepared<em><small>(no title)</small></em></span></p>
+    
+    <p style="font-size: 16px; font-family: Arial; margin: 43px 0 2px 62px; padding: 0;"><span class="formElementOnEditor" contenteditable="false" data-row-name="element12-hiddenTitle">Personal Information: First name (required)<em><small>(no title)</small></em></span>&nbsp;<span class="formElementOnEditor" contenteditable="false" data-row-name="element13-hiddenTitle">Personal Information: Last name (required)<em><small>(no title)</small></em></span></p>
+    <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;">7 Chauncy Street</p>  
+    <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;">Boston, MA 02111</p>
+    
     <hr style="margin: 56px 0 0 0; padding: 0;" />
     <h1
         style="font-size: 27.3px; font-family: Arial; font-weight: 700; margin-top: 48px; margin-left: 16px; padding: 0;">
         Su nueva CharlieCard para mayores</h1>
 
-    <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;"><strong>Número de
-            serie</strong><br />
-        <span class="formElementOnEditor" contenteditable="false" data-row-name="element109-hiddenTitle">Prepare Card:
-            New serial card number (requir...<em><small>(no title)</small></em></span>
+    <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;"><strong>Número de serie</strong><br />
+        <span class="formElementOnEditor" contenteditable="false" data-row-name="element109-hiddenTitle">Prepare Card: New serial card number (requir...<em><small>(no title)</small></em></span>
     </p>
 
     <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;">Necesitará este
         número en caso de pérdida, robo o daño de su tarjeta.</p>
 
     <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;"><strong>Transferencia mensual</strong><br />
-        <span class="formElementOnEditor" contenteditable="false" data-row-name="element111-hiddenTitle">Prepare Card:
-            Monthly transfer? (required)<em><small>(no title)</small></em></span>
+        <span class="formElementOnEditor" contenteditable="false" data-row-name="element111-hiddenTitle">Prepare Card: Monthly transfer? (required)<em><small>(no title)</small></em></span>
     </p>
 
     <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;"><strong>Transferencia del valor almacenado</strong><br />
-        <span class="formElementOnEditor" contenteditable="false" data-row-name="element110-hiddenTitle">Prepare Card:
-            Stored value transfer (require...<em><small>(no title)</small></em></span>
+        <span class="formElementOnEditor" contenteditable="false" data-row-name="element110-hiddenTitle">Prepare Card: Stored value transfer (require...<em><small>(no title)</small></em></span>
+    </p>
+
+    <p>&nbsp;</p>
+
+    <h2 style="font-size: 20.8px; font-family: Arial; font-weight: 700; margin-left: 16px; padding: 0;">
+        <strong>Duración de la tarjeta</strong>
+    </h2>
+
+    <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;">
+        <span class="formElementOnEditor" contenteditable="false" data-row-name="element196-hiddenTitle">Generated Content: Card Duration Text<em><small>(no title)</small></em></span>
     </p>
 
     <p>&nbsp;</p>

--- a/assets/senior_html/pdfs/mailing_slips/mail-slip-chinese-simplified.html
+++ b/assets/senior_html/pdfs/mailing_slips/mail-slip-chinese-simplified.html
@@ -1,74 +1,58 @@
-<div style="margin:0px; padding: 0"><img 
-        src="https://mbta.prod.simpligov.com/prod/portal/file/51d7628117ce4c0c9cb0000188390b62.png?t=1633355953036"
-        style="width: 335.4px; height: 62.4px; margin-left: 8px; margin-top: 6px" />
-    <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">MBTA Senior CharlieCard
-    </p>
-
-    <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">Order date (订购日期): <span
-            class="formElementOnEditor" contenteditable="false" data-row-name="element130-hiddenTitle">Prepare Card:
-            Date card prepared<em><small>(no title)</small></em></span></p>
-
-            <p style="font-size: 16px; font-family: Arial; margin: 43px 0 2px 62px; padding: 0;"><span
-                class="formElementOnEditor" contenteditable="false" data-row-name="element12-hiddenTitle">Personal
-                Information: First name (required)<em><small>(no title)</small></em></span>&nbsp;<span
-                class="formElementOnEditor" contenteditable="false" data-row-name="element13-hiddenTitle">Personal
-                Information: Last name (required)<em><small>(no title)</small></em></span></p>
-        
-            <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;"><span class="formElementOnEditor"
-                contenteditable="false" data-row-name="element22-hiddenTitle">Getting Your Card: Street Address
-                (required)<em><small>(no title)</small></em></span></p>
-        
-            <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;"><span class="formElementOnEditor"
-                contenteditable="false" data-row-name="element23-hiddenTitle">Getting Your Card: Apartment, suite,
-                building<em><small>(no title)</small></em></span></p>
-        
-            <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;"><span class="formElementOnEditor"
-                contenteditable="false" data-row-name="element24-hiddenTitle">Getting Your Card: City
-                (required)<em><small>(no title)</small></em></span>, <span class="formElementOnEditor"
-                contenteditable="false" data-row-name="element25-hiddenTitle">Getting Your Card: State or US territory
-                (require...<em><small>(no title)</small></em></span> <span class="formElementOnEditor"
-                contenteditable="false" data-row-name="element26-hiddenTitle">Getting Your Card: Zip code
-                (required)<em><small>(no title)</small></em></span></p>
+<div style="margin:0px; padding: 0"><img src="https://mbta.prod.simpligov.com/prod/portal/file/51d7628117ce4c0c9cb0000188390b62.png?t=1633355953036" style="width: 335.4px; height: 62.4px; margin-left: 8px; margin-top: 6px" />
+    <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">MBTA Senior CharlieCard</p>
+    <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">Order date (订购日期): <span class="formElementOnEditor" contenteditable="false" data-row-name="element130-hiddenTitle">Prepare Card: Date card prepared<em><small>(no title)</small></em></span></p>
+    
+    <p style="font-size: 16px; font-family: Arial; margin: 43px 0 2px 62px; padding: 0;"><span class="formElementOnEditor" contenteditable="false" data-row-name="element12-hiddenTitle">Personal Information: First name (required)<em><small>(no title)</small></em></span>&nbsp;<span class="formElementOnEditor" contenteditable="false" data-row-name="element13-hiddenTitle">Personal Information: Last name (required)<em><small>(no title)</small></em></span></p>
+    <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;"><span class="formElementOnEditor" contenteditable="false" data-row-name="element22-hiddenTitle">Getting Your Card: Street Address (required)<em><small>(no title)</small></em></span></p>
+    <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;"><span class="formElementOnEditor" contenteditable="false" data-row-name="element23-hiddenTitle">Getting Your Card: Apartment, suite, building<em><small>(no title)</small></em></span></p>
+    <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;"><span class="formElementOnEditor" contenteditable="false" data-row-name="element24-hiddenTitle">Getting Your Card: City (required)<em><small>(no title)</small></em></span>, <span class="formElementOnEditor" contenteditable="false" data-row-name="element25-hiddenTitle">Getting Your Card: State or US territory (require...<em><small>(no title)</small></em></span> <span class="formElementOnEditor" contenteditable="false" data-row-name="element26-hiddenTitle">Getting Your Card: Zip code (required)<em><small>(no title)</small></em></span></p>
 
     <hr style="margin: 56px 0 0 0; padding: 0;" />
     <h1 style="font-size: 27.3px; font-family: Arial; font-weight: 700; margin-top: 48px; margin-left: 16px; padding: 0;">你的全新老年人查理卡</h1>
     
     <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;"><strong>序号</strong><br />
-    <span class="formElementOnEditor" contenteditable="false" data-row-name="element109-hiddenTitle">Prepare Card: New serial card number (requir...<em><small>(no title)</small></em></span></p>
+        <span class="formElementOnEditor" contenteditable="false" data-row-name="element109-hiddenTitle">Prepare Card: New serial card number (requir...<em><small>(no title)</small></em></span>
+    </p>
     
-    <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;">如果你的卡丢失, 被盗或损坏, 你将需要此号码。 </p>
+    <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;">如果你的卡丢失, 被盗或损坏, 你将需要此号码。</p>
     
     <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;"><strong>每月转账</strong><br />
-    <span class="formElementOnEditor" contenteditable="false" data-row-name="element111-hiddenTitle">Prepare Card: Monthly transfer? (required)<em><small>(no title)</small></em></span></p>
+        <span class="formElementOnEditor" contenteditable="false" data-row-name="element111-hiddenTitle">Prepare Card: Monthly transfer? (required)<em><small>(no title)</small></em></span>
+    </p>
     
     <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;"><strong>储存价值转账</strong><br />
-    <span class="formElementOnEditor" contenteditable="false" data-row-name="element110-hiddenTitle">Prepare Card: Stored value transfer (require...<em><small>(no title)</small></em></span></p>
+        <span class="formElementOnEditor" contenteditable="false" data-row-name="element110-hiddenTitle">Prepare Card: Stored value transfer (require...<em><small>(no title)</small></em></span>
+    </p>
     
     <p>&nbsp;</p>
-    
-    <h2 style="font-size: 20.8px; font-family: Arial; font-weight: 700; margin-left: 16px; padding: 0;">
-        有问题吗?</h2>
 
-    <p style="font-size: 16px; font-family: Arial; font-weight: 700; margin-left: 16px; padding: 0;">
-        联系客户支持</p>
+    <h2 style="font-size: 20.8px; font-family: Arial; font-weight: 700; margin-left: 16px; padding: 0;">
+        <strong>卡片时长</strong>
+    </h2>
+
+    <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;">
+        <span class="formElementOnEditor" contenteditable="false" data-row-name="element196-hiddenTitle">Generated Content: Card Duration Text<em><small>(no title)</small></em></span>
+    </p>
+
+    <p>&nbsp;</p>
+    
+    <h2 style="font-size: 20.8px; font-family: Arial; font-weight: 700; margin-left: 16px; padding: 0;">有问题吗?</h2>
+    <p style="font-size: 16px; font-family: Arial; font-weight: 700; margin-left: 16px; padding: 0;">联系客户支持</p>
 
     <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;">
         周一 &ndash; 周五: 早6:30 &ndash; 晚8点<br />
-        周六 &ndash; 周日: 早8点 &ndash; 下午4点</p>
+        周六 &ndash; 周日: 早8点 &ndash; 下午4点
+    </p>
 
     <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;">
         主热线: 617-222-3200<br />
         免费电话: 800-392-6100<br />
-        TTY: 617-222-5146</p>
+        TTY: 617-222-5146
+    </p>
 
     <p>&nbsp;</p>
 
-    <p style="font-size: 16px; font-family: Arial; font-weight: 700; margin-left: 16px; padding: 0;">
-        访问查理卡出售店</p>
-
-    <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;">
-        位于Downtown Crossing车站, 地址是7 Chauncy Street (地下大厅), Boston, MA 02111。</p>
-
-    <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;">
-        由此查看查理卡出售店营业时间 <strong>mbta.com/fares/charliecard-store</strong></p>
+    <p style="font-size: 16px; font-family: Arial; font-weight: 700; margin-left: 16px; padding: 0;">访问查理卡出售店</p>
+    <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;">位于Downtown Crossing车站, 地址是7 Chauncy Street (地下大厅), Boston, MA 02111。</p>
+    <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;">由此查看查理卡出售店营业时间 <strong>mbta.com/fares/charliecard-store</strong></p>
 </div>

--- a/assets/senior_html/pdfs/mailing_slips/mail-slip-chinese-traditional.html
+++ b/assets/senior_html/pdfs/mailing_slips/mail-slip-chinese-traditional.html
@@ -1,34 +1,12 @@
-<div style="margin:0px; padding: 0"><img alt="MBTA logo"
-    src="https://mbta.prod.simpligov.com/prod/portal/file/51d7628117ce4c0c9cb0000188390b62.png?t=1633355953036"
-    style="width: 335.4px; height: 62.4px; margin-left: 8px; margin-top: 6px" />
-<p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">MBTA Senior CharlieCard
-</p>
+<div style="margin:0px; padding: 0"><img alt="MBTA logo" src="https://mbta.prod.simpligov.com/prod/portal/file/51d7628117ce4c0c9cb0000188390b62.png?t=1633355953036" style="width: 335.4px; height: 62.4px; margin-left: 8px; margin-top: 6px" />
+<p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">MBTA Senior CharlieCard</p>
 
-<p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">Order date (訂購日期): <span
-    class="formElementOnEditor" contenteditable="false" data-row-name="element130-hiddenTitle">Prepare Card:
-    Date card prepared<em><small>(no title)</small></em></span></p>
+<p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">Order date (訂購日期): <span class="formElementOnEditor" contenteditable="false" data-row-name="element130-hiddenTitle">Prepare Card: Date card prepared<em><small>(no title)</small></em></span></p>
 
-<p style="font-size: 16px; font-family: Arial; margin: 43px 0 2px 62px; padding: 0;"><span
-    class="formElementOnEditor" contenteditable="false" data-row-name="element12-hiddenTitle">Personal
-    Information: First name (required)<em><small>(no title)</small></em></span>&nbsp;<span
-    class="formElementOnEditor" contenteditable="false" data-row-name="element13-hiddenTitle">Personal
-    Information: Last name (required)<em><small>(no title)</small></em></span></p>
-
-<p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;"><span class="formElementOnEditor"
-    contenteditable="false" data-row-name="element22-hiddenTitle">Getting Your Card: Street Address
-    (required)<em><small>(no title)</small></em></span></p>
-
-<p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;"><span class="formElementOnEditor"
-    contenteditable="false" data-row-name="element23-hiddenTitle">Getting Your Card: Apartment, suite,
-    building<em><small>(no title)</small></em></span></p>
-
-<p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;"><span class="formElementOnEditor"
-    contenteditable="false" data-row-name="element24-hiddenTitle">Getting Your Card: City
-    (required)<em><small>(no title)</small></em></span>, <span class="formElementOnEditor"
-    contenteditable="false" data-row-name="element25-hiddenTitle">Getting Your Card: State or US territory
-    (require...<em><small>(no title)</small></em></span> <span class="formElementOnEditor"
-    contenteditable="false" data-row-name="element26-hiddenTitle">Getting Your Card: Zip code
-    (required)<em><small>(no title)</small></em></span></p>
+<p style="font-size: 16px; font-family: Arial; margin: 43px 0 2px 62px; padding: 0;"><span class="formElementOnEditor" contenteditable="false" data-row-name="element12-hiddenTitle">Personal Information: First name (required)<em><small>(no title)</small></em></span>&nbsp;<span class="formElementOnEditor" contenteditable="false" data-row-name="element13-hiddenTitle">Personal Information: Last name (required)<em><small>(no title)</small></em></span></p>
+<p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;"><span class="formElementOnEditor" contenteditable="false" data-row-name="element22-hiddenTitle">Getting Your Card: Street Address (required)<em><small>(no title)</small></em></span></p>
+<p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;"><span class="formElementOnEditor" contenteditable="false" data-row-name="element23-hiddenTitle">Getting Your Card: Apartment, suite, building<em><small>(no title)</small></em></span></p>
+<p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;"><span class="formElementOnEditor" contenteditable="false" data-row-name="element24-hiddenTitle">Getting Your Card: City (required)<em><small>(no title)</small></em></span>, <span class="formElementOnEditor" contenteditable="false" data-row-name="element25-hiddenTitle">Getting Your Card: State or US territory (require...<em><small>(no title)</small></em></span> <span class="formElementOnEditor" contenteditable="false" data-row-name="element26-hiddenTitle">Getting Your Card: Zip code (required)<em><small>(no title)</small></em></span></p>
 
 
 <hr style="margin: 56px 0 0 0; padding: 0;" />
@@ -45,6 +23,16 @@
     <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;"><strong>儲存價值轉賬</strong><br />
     <span class="formElementOnEditor" contenteditable="false" data-row-name="element110-hiddenTitle">Prepare Card: Stored value transfer (require...<em><small>(no title)</small></em></span></p>
     
+    <p>&nbsp;</p>
+
+    <h2 style="font-size: 20.8px; font-family: Arial; font-weight: 700; margin-left: 16px; padding: 0;">
+        <strong>卡有效期</strong>
+    </h2>
+
+    <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;">
+        <span class="formElementOnEditor" contenteditable="false" data-row-name="element196-hiddenTitle">Generated Content: Card Duration Text<em><small>(no title)</small></em></span>
+    </p>
+
     <p>&nbsp;</p>
     
     <h2 style="font-size: 20.8px; font-family: Arial; font-weight: 700; margin-left: 16px; padding: 0;">

--- a/assets/senior_html/pdfs/mailing_slips/mail-slip-english.html
+++ b/assets/senior_html/pdfs/mailing_slips/mail-slip-english.html
@@ -1,50 +1,39 @@
-<div style="margin:0px; padding: 0"><img alt="MBTA logo"
-        src="https://mbta.prod.simpligov.com/prod/portal/file/51d7628117ce4c0c9cb0000188390b62.png?t=1633355953036"
-        style="width: 335.4px; height: 62.4px; margin-left: 8px; margin-top: 6px" />
-    <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">MBTA Senior CharlieCard
-    </p>
-
+<div style="margin:0px; padding: 0"><img alt="MBTA logo" src="https://mbta.prod.simpligov.com/prod/portal/file/51d7628117ce4c0c9cb0000188390b62.png?t=1633355953036" style="width: 335.4px; height: 62.4px; margin-left: 8px; margin-top: 6px" />
+    <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">MBTA Senior CharlieCard</p>
     <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">Order date: <span class="formElementOnEditor" contenteditable="false" data-row-name="element130-hiddenTitle">Prepare Card: Date card prepared<em><small>(no title)</small></em></span></p>
+
     <p style="font-size: 16px; font-family: Arial; margin: 43px 0 2px 62px; padding: 0;"><span class="formElementOnEditor" contenteditable="false" data-row-name="element12-hiddenTitle">Personal Information: First name (required)<em><small>(no title)</small></em></span>&nbsp;<span class="formElementOnEditor" contenteditable="false" data-row-name="element13-hiddenTitle">Personal Information: Last name (required)<em><small>(no title)</small></em></span></p>
-    <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;"><span class="formElementOnEditor"
-        contenteditable="false" data-row-name="element22-hiddenTitle">Getting Your Card: Street Address
-        (required)<em><small>(no title)</small></em></span></p>
-
-    <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;"><span class="formElementOnEditor"
-        contenteditable="false" data-row-name="element23-hiddenTitle">Getting Your Card: Apartment, suite,
-        building<em><small>(no title)</small></em></span></p>
-
-    <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;"><span class="formElementOnEditor"
-        contenteditable="false" data-row-name="element24-hiddenTitle">Getting Your Card: City
-        (required)<em><small>(no title)</small></em></span>, <span class="formElementOnEditor"
-        contenteditable="false" data-row-name="element25-hiddenTitle">Getting Your Card: State or US territory
-        (require...<em><small>(no title)</small></em></span> <span class="formElementOnEditor"
-        contenteditable="false" data-row-name="element26-hiddenTitle">Getting Your Card: Zip code
-        (required)<em><small>(no title)</small></em></span></p>
-
-
+    <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;"><span class="formElementOnEditor" contenteditable="false" data-row-name="element22-hiddenTitle">Getting Your Card: Street Address (required)<em><small>(no title)</small></em></span></p>
+    <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;"><span class="formElementOnEditor" contenteditable="false" data-row-name="element23-hiddenTitle">Getting Your Card: Apartment, suite, building<em><small>(no title)</small></em></span></p>
+    <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;"><span class="formElementOnEditor" contenteditable="false" data-row-name="element24-hiddenTitle">Getting Your Card: City (required)<em><small>(no title)</small></em></span>, <span class="formElementOnEditor" contenteditable="false" data-row-name="element25-hiddenTitle">Getting Your Card: State or US territory (require...<em><small>(no title)</small></em></span> <span class="formElementOnEditor" contenteditable="false" data-row-name="element26-hiddenTitle">Getting Your Card: Zip code (required)<em><small>(no title)</small></em></span></p>
+    
+    
     <hr style="margin: 56px 0 0 0; padding: 0;" />
     <h1 style="font-size: 27.3px; font-family: Arial; font-weight: 700; margin-top: 48px; margin-left: 16px; padding: 0;">
         Your Senior CharlieCard</h1>
 
     <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;"><strong>Serial number</strong><br />
-        <span class="formElementOnEditor" contenteditable="false" data-row-name="element109-hiddenTitle">Prepare Card:
-            New serial card number (requir...<em><small>(no title)</small></em></span>
+        <span class="formElementOnEditor" contenteditable="false" data-row-name="element109-hiddenTitle">Prepare Card: New serial card number (requir...<em><small>(no title)</small></em></span>
     </p>
 
-    <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;">You will need this number if your
-        card is lost, stolen, or damaged.</p>
+    <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;">You will need this number if your card is lost, stolen, or damaged.</p>
 
-    <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;"><strong>Monthly
-            transfer</strong><br />
-        <span class="formElementOnEditor" contenteditable="false" data-row-name="element111-hiddenTitle">Prepare Card:
-            Monthly transfer? (required)<em><small>(no title)</small></em></span>
+    <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;"><strong>Monthly transfer</strong><br />
+        <span class="formElementOnEditor" contenteditable="false" data-row-name="element111-hiddenTitle">Prepare Card: Monthly transfer? (required)<em><small>(no title)</small></em></span>
     </p>
 
-    <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;"><strong>Stored value
-            transfer</strong><br />
-        <span class="formElementOnEditor" contenteditable="false" data-row-name="element110-hiddenTitle">Prepare Card:
-            Stored value transfer (require...<em><small>(no title)</small></em></span>
+    <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;"><strong>Stored value transfer</strong><br />
+        <span class="formElementOnEditor" contenteditable="false" data-row-name="element110-hiddenTitle">Prepare Card: Stored value transfer (require...<em><small>(no title)</small></em></span>
+    </p>
+
+    <p>&nbsp;</p>
+
+    <h2 style="font-size: 20.8px; font-family: Arial; font-weight: 700; margin-left: 16px; padding: 0;">
+        <strong>Card duration</strong>
+    </h2>
+
+    <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;">
+        <span class="formElementOnEditor" contenteditable="false" data-row-name="element196-hiddenTitle">Generated Content: Card Duration Text<em><small>(no title)</small></em></span>
     </p>
 
     <p>&nbsp;</p>
@@ -53,8 +42,7 @@
         <strong>Questions?</strong>
     </h2>
 
-    <p style="font-size: 16px; font-family: Arial; font-weight: 700; margin-left: 16px; padding: 0;">Contact Customer
-        Support</p>
+    <p style="font-size: 16px; font-family: Arial; font-weight: 700; margin-left: 16px; padding: 0;">Contact Customer Support</p>
 
     <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;">Monday &ndash; Friday: 6:30 AM
         &ndash; 8 PM<br />
@@ -75,6 +63,6 @@
         lines: 7 Chauncy Street, Boston, MA 02111.</p>
 
     <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;">View CharlieCard Store hours at
-        <strong>mbta.com/fares/charliecard-store&nbsp;</strong>
+        <strong>mbta.com/fares/charliecard-store</strong>
     </p>
 </div>

--- a/assets/senior_html/pdfs/mailing_slips/mail-slip-portuguese.html
+++ b/assets/senior_html/pdfs/mailing_slips/mail-slip-portuguese.html
@@ -1,59 +1,43 @@
-<div style="margin:0; padding: 0"><img src="https://mbta.prod.simpligov.com/prod/portal/file/51d7628117ce4c0c9cb0000188390b62.png?t=1633355953036"
-        style="width: 335.4px; height: 62.4px; margin-left: 8px; margin-top: 6px" />
-    <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">MBTA Senior CharlieCard
-    </p>
+<div style="margin:0px; padding: 0"><img alt="MBTA logo" src="https://mbta.prod.simpligov.com/prod/portal/file/51d7628117ce4c0c9cb0000188390b62.png?t=1633355953036" style="width: 335.4px; height: 62.4px; margin-left: 8px; margin-top: 6px" />
+    <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">MBTA Senior CharlieCard</p>
+    
+    <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">Order date (data do pedido): <span class="formElementOnEditor" contenteditable="false" data-row-name="element130-hiddenTitle">Prepare Card: Date card prepared<em><small>(no title)</small></em></span></p>
 
-    <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">Order date (data do pedido): <span
-        class="formElementOnEditor" contenteditable="false" data-row-name="element130-hiddenTitle">Prepare Card:
-        Date card prepared<em><small>(no title)</small></em></span></p>
-
-    <p style="font-size: 16px; font-family: Arial; margin: 43px 0 2px 62px; padding: 0;"><span
-        class="formElementOnEditor" contenteditable="false" data-row-name="element12-hiddenTitle">Personal
-        Information: First name (required)<em><small>(no title)</small></em></span>&nbsp;<span
-        class="formElementOnEditor" contenteditable="false" data-row-name="element13-hiddenTitle">Personal
-        Information: Last name (required)<em><small>(no title)</small></em></span></p>
-        
-    <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;"><span class="formElementOnEditor"
-        contenteditable="false" data-row-name="element22-hiddenTitle">Getting Your Card: Street Address
-        (required)<em><small>(no title)</small></em></span></p>
-        
-    <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;"><span class="formElementOnEditor"
-        contenteditable="false" data-row-name="element23-hiddenTitle">Getting Your Card: Apartment, suite,
-        building<em><small>(no title)</small></em></span></p>
-        
-    <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;"><span class="formElementOnEditor"
-        contenteditable="false" data-row-name="element24-hiddenTitle">Getting Your Card: City
-        (required)<em><small>(no title)</small></em></span>, <span class="formElementOnEditor"
-        contenteditable="false" data-row-name="element25-hiddenTitle">Getting Your Card: State or US territory
-        (require...<em><small>(no title)</small></em></span> <span class="formElementOnEditor"
-        contenteditable="false" data-row-name="element26-hiddenTitle">Getting Your Card: Zip code
-        (required)<em><small>(no title)</small></em></span></p>
-
+    <p style="font-size: 16px; font-family: Arial; margin: 43px 0 2px 62px; padding: 0;"><span class="formElementOnEditor" contenteditable="false" data-row-name="element12-hiddenTitle">Personal Information: First name (required)<em><small>(no title)</small></em></span>&nbsp;<span class="formElementOnEditor" contenteditable="false" data-row-name="element13-hiddenTitle">Personal Information: Last name (required)<em><small>(no title)</small></em></span></p>
+    <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;"><span class="formElementOnEditor" contenteditable="false" data-row-name="element22-hiddenTitle">Getting Your Card: Street Address (required)<em><small>(no title)</small></em></span></p>
+    <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;"><span class="formElementOnEditor" contenteditable="false" data-row-name="element23-hiddenTitle">Getting Your Card: Apartment, suite, building<em><small>(no title)</small></em></span></p>
+    <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;"><span class="formElementOnEditor" contenteditable="false" data-row-name="element24-hiddenTitle">Getting Your Card: City (required)<em><small>(no title)</small></em></span>, <span class="formElementOnEditor" contenteditable="false" data-row-name="element25-hiddenTitle">Getting Your Card: State or US territory (require...<em><small>(no title)</small></em></span> <span class="formElementOnEditor" contenteditable="false" data-row-name="element26-hiddenTitle">Getting Your Card: Zip code (required)<em><small>(no title)</small></em></span></p>
+    
+    
     <hr style="margin: 56px 0 0 0; padding: 0;" />
     <h1 style="font-size:27.3px; font-family: Arial; font-weight: 700; margin-top: 48px; margin-left: 16px; padding: 0;">
         O novo Senior CharlieCard</h1>
 
-    <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;"><strong>Número de
-            série</strong><br />
-        <span class="formElementOnEditor" contenteditable="false" data-row-name="element109-hiddenTitle">Prepare Card:
-            New serial card number (requir...<em><small>(no title)</small></em></span>
+    <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;"><strong>Número de série</strong><br />
+        <span class="formElementOnEditor" contenteditable="false" data-row-name="element109-hiddenTitle">Prepare Card: New serial card number (requir...<em><small>(no title)</small></em></span>
     </p>
 
     <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;">Precisará desse número se o cartão
         for perdido, roubado ou danificado.</p>
 
-    <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;"><strong>Transferência
-            mensal</strong><br />
-        <span class="formElementOnEditor" contenteditable="false" data-row-name="element111-hiddenTitle">Prepare Card:
-            Monthly transfer? (required)<em><small>(no title)</small></em></span>
+    <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;"><strong>Transferência mensal</strong><br />
+        <span class="formElementOnEditor" contenteditable="false" data-row-name="element111-hiddenTitle">Prepare Card: Monthly transfer? (required)<em><small>(no title)</small></em></span>
     </p>
 
-    <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;"><strong>Transferência de valor
-            depositado</strong><br />
-        <span class="formElementOnEditor" contenteditable="false" data-row-name="element110-hiddenTitle">Prepare Card:
-            Stored value transfer (require...<em><small>(no title)</small></em></span>
+    <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;"><strong>Transferência de valor depositado</strong><br />
+        <span class="formElementOnEditor" contenteditable="false" data-row-name="element110-hiddenTitle">Prepare Card: Stored value transfer (require...<em><small>(no title)</small></em></span>
     </p>
 
+    <p>&nbsp;</p>
+
+    <h2 style="font-size: 20.8px; font-family: Arial; font-weight: 700; margin-left: 16px; padding: 0;">
+        <strong>Duração do cartão</strong>
+    </h2>
+    
+    <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;">
+        <span class="formElementOnEditor" contenteditable="false" data-row-name="element196-hiddenTitle">Generated Content: Card Duration Text<em><small>(no title)</small></em></span>
+    </p>
+    
     <p>&nbsp;</p>
 
     <h2 style="font-size:20.8px; font-family: Arial; font-weight: 700; margin-left: 16px; padding: 0;">
@@ -71,7 +55,7 @@
         Hotline principal: 617-222-3200<br />
         Gratuito: 800-392-6100<br />
         TTY:617-222-5146</p>
-
+    
     <p>&nbsp;</p>
 
     <p style="font-size: 16px; font-family: Arial; font-weight: 700; margin-left: 16px; padding: 0;">

--- a/assets/senior_html/pdfs/mailing_slips/mail-slip-spanish.html
+++ b/assets/senior_html/pdfs/mailing_slips/mail-slip-spanish.html
@@ -1,57 +1,40 @@
-<div style="margin:0; padding: 0"><img 
-        src="https://mbta.prod.simpligov.com/prod/portal/file/51d7628117ce4c0c9cb0000188390b62.png?t=1633355953036"
-        style="width: 335.4px; height: 62.4px; margin-left: 8px; margin-top: 6px" />
-    <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">MBTA Senior CharlieCard
-    </p>
+<div style="margin:0px; padding: 0"><img alt="MBTA logo" src="https://mbta.prod.simpligov.com/prod/portal/file/51d7628117ce4c0c9cb0000188390b62.png?t=1633355953036" style="width: 335.4px; height: 62.4px; margin-left: 8px; margin-top: 6px" />
+    <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">MBTA Senior CharlieCard</p>
+    <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">Order date (fecha del pedido): <span class="formElementOnEditor" contenteditable="false" data-row-name="element130-hiddenTitle">Prepare Card: Date card prepared<em><small>(no title)</small></em></span></p>
 
-    <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">Order date (fecha del pedido): <span
-        class="formElementOnEditor" contenteditable="false" data-row-name="element130-hiddenTitle">Prepare Card:
-        Date card prepared<em><small>(no title)</small></em></span></p>
-
-    <p style="font-size: 16px; font-family: Arial; margin: 43px 0 2px 62px; padding: 0;"><span
-        class="formElementOnEditor" contenteditable="false" data-row-name="element12-hiddenTitle">Personal
-        Information: First name (required)<em><small>(no title)</small></em></span>&nbsp;<span
-        class="formElementOnEditor" contenteditable="false" data-row-name="element13-hiddenTitle">Personal
-        Information: Last name (required)<em><small>(no title)</small></em></span></p>
-
-    <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;"><span class="formElementOnEditor"
-        contenteditable="false" data-row-name="element22-hiddenTitle">Getting Your Card: Street Address
-        (required)<em><small>(no title)</small></em></span></p>
-
-    <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;"><span class="formElementOnEditor"
-        contenteditable="false" data-row-name="element23-hiddenTitle">Getting Your Card: Apartment, suite,
-        building<em><small>(no title)</small></em></span></p>
-
-    <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;"><span class="formElementOnEditor"
-        contenteditable="false" data-row-name="element24-hiddenTitle">Getting Your Card: City
-        (required)<em><small>(no title)</small></em></span>, <span class="formElementOnEditor"
-        contenteditable="false" data-row-name="element25-hiddenTitle">Getting Your Card: State or US territory
-        (require...<em><small>(no title)</small></em></span> <span class="formElementOnEditor"
-        contenteditable="false" data-row-name="element26-hiddenTitle">Getting Your Card: Zip code
-        (required)<em><small>(no title)</small></em></span></p>
-
+    <p style="font-size: 16px; font-family: Arial; margin: 43px 0 2px 62px; padding: 0;"><span class="formElementOnEditor" contenteditable="false" data-row-name="element12-hiddenTitle">Personal Information: First name (required)<em><small>(no title)</small></em></span>&nbsp;<span class="formElementOnEditor" contenteditable="false" data-row-name="element13-hiddenTitle">Personal Information: Last name (required)<em><small>(no title)</small></em></span></p>
+    <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;"><span class="formElementOnEditor" contenteditable="false" data-row-name="element22-hiddenTitle">Getting Your Card: Street Address (required)<em><small>(no title)</small></em></span></p>
+    <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;"><span class="formElementOnEditor" contenteditable="false" data-row-name="element23-hiddenTitle">Getting Your Card: Apartment, suite, building<em><small>(no title)</small></em></span></p>
+    <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;"><span class="formElementOnEditor" contenteditable="false" data-row-name="element24-hiddenTitle">Getting Your Card: City (required)<em><small>(no title)</small></em></span>, <span class="formElementOnEditor" contenteditable="false" data-row-name="element25-hiddenTitle">Getting Your Card: State or US territory (require...<em><small>(no title)</small></em></span> <span class="formElementOnEditor" contenteditable="false" data-row-name="element26-hiddenTitle">Getting Your Card: Zip code (required)<em><small>(no title)</small></em></span></p>
+    
     <hr style="margin: 56px 0 0 0; padding: 0;" />
     <h1
         style="font-size: 27.3px; font-family: Arial; font-weight: 700; margin-top: 48px; margin-left: 16px; padding: 0;">
         Su nueva CharlieCard para mayores</h1>
 
-    <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;"><strong>Número de
-            serie</strong><br />
-        <span class="formElementOnEditor" contenteditable="false" data-row-name="element109-hiddenTitle">Prepare Card:
-            New serial card number (requir...<em><small>(no title)</small></em></span>
+    <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;"><strong>Número de serie</strong><br />
+        <span class="formElementOnEditor" contenteditable="false" data-row-name="element109-hiddenTitle">Prepare Card: New serial card number (requir...<em><small>(no title)</small></em></span>
     </p>
 
     <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;">Necesitará este
         número en caso de pérdida, robo o daño de su tarjeta.</p>
 
     <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;"><strong>Transferencia mensual</strong><br />
-        <span class="formElementOnEditor" contenteditable="false" data-row-name="element111-hiddenTitle">Prepare Card:
-            Monthly transfer? (required)<em><small>(no title)</small></em></span>
+        <span class="formElementOnEditor" contenteditable="false" data-row-name="element111-hiddenTitle">Prepare Card: Monthly transfer? (required)<em><small>(no title)</small></em></span>
     </p>
 
     <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;"><strong>Transferencia del valor almacenado</strong><br />
-        <span class="formElementOnEditor" contenteditable="false" data-row-name="element110-hiddenTitle">Prepare Card:
-            Stored value transfer (require...<em><small>(no title)</small></em></span>
+        <span class="formElementOnEditor" contenteditable="false" data-row-name="element110-hiddenTitle">Prepare Card: Stored value transfer (require...<em><small>(no title)</small></em></span>
+    </p>
+
+    <p>&nbsp;</p>
+
+    <h2 style="font-size: 20.8px; font-family: Arial; font-weight: 700; margin-left: 16px; padding: 0;">
+        <strong>Duración de la tarjeta</strong>
+    </h2>
+
+    <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;">
+        <span class="formElementOnEditor" contenteditable="false" data-row-name="element196-hiddenTitle">Generated Content: Card Duration Text<em><small>(no title)</small></em></span>
     </p>
 
     <p>&nbsp;</p>

--- a/assets/tap_html/emails/approved_by_mail_emails/approved-by-mail-chinese-simplified.html
+++ b/assets/tap_html/emails/approved_by_mail_emails/approved-by-mail-chinese-simplified.html
@@ -130,36 +130,17 @@
 
         <!-- Body copy -->
         <h1>你的交通乘车通票 (TAP) 查里卡正在发送过程中！</h1>
-
         <p>你的交通乘车通票 (TAP) 查里卡将在3-5个工作日内通过USPS寄到你的邮寄地址。</p>
 
         <h2>关于你的卡</h2>
-
         <ul>
-          <li>你可以将你的<a href="https://www.mbta.com/fares/reduced/transportation-access-pass">交通乘车通票 (TAP) 查里卡</a>用于：
-
-            <ul>
-              <li>
-                <strong>单程票价可享受50%的折扣</strong>，适用于公交车、地铁、巴士快车、通勤列车和渡轮。
-              </li>
-              <li>
-                <strong>30美元的月票或10美元的7日通票</strong>，可无限次乘坐巴士、地铁、1A区通勤列车和内港渡轮。
-              </li>
-              <li>
-                巴士快车、通勤列车和渡轮的<a href="https://www.mbta.com/fares/reduced#passes">折扣月票</a>。
-              </li>
-            </ul>
-            
-          </li>
+          <li>了解<a href="https://www.mbta.com/fares/reduced/transportation-access-pass">如何使用你的卡</a>。</li>
           <li>如果你的卡损坏、丢失或被盗，你可以使用网上申请或致打电话给客户支持617-222-3200申请补发卡。</li>
           <li>如果你的卡是续期或更换卡，你的月票和旧卡中的余额将自动转移到你的新卡中。</li>
-          <li>
-            <strong><span class="formElementOnEditor" contenteditable="false" data-row-name="element206-hiddenTitle">Generated Content: Card Duration Text<em><small>(no title)</small></em></span></strong>
-          </li>
+          <li><strong><span class="formElementOnEditor" contenteditable="false" data-row-name="element206-hiddenTitle">Generated Content: Card Duration Text<em><small>(no title)</small></em></span></strong></li>
         </ul>
 
         <h2>有问题吗?</h2>
-
         <p>
           请联系<a href="https://www.mbta.com/customer-support">客户支持 (使用网上表格) </a>
           或给下列号码打电话。
@@ -177,8 +158,10 @@
           TTY: <a href="tel:617-222-5146">617-222-5146</a>
         </p>
 
-        <h2>注册以接收有关MBTA无障碍性的电子邮件</h2>
+        <h2>你是否想了解更多有关T的信息？</h2>
+        <p>我们的移动中心（<a href="https://www.mbta.com/accessibility/mbta-mobility-center">Mobility Center</a>）交通培训员随时准备为你提供帮助。要了解如何安全、独立地乘坐T、计划出行、使用移动应用程序以及获得其他交通服务，请联系<a href="tel:617-337-2756">617-337-2756</a>或<a href="mailto:howtotravel@mbta.com">howtotravel@mbta.com</a>。</p>
 
+        <h2>注册以接收有关MBTA无障碍性的电子邮件</h2>
         <p>加入MBTA的系统范围内无障碍性部门的电子邮件名单，以获取有关我们正在开展的工作的定期更新以及即将举行的会议通知。</p>
 
         <!-- Button -->

--- a/assets/tap_html/emails/approved_by_mail_emails/approved-by-mail-english.html
+++ b/assets/tap_html/emails/approved_by_mail_emails/approved-by-mail-english.html
@@ -130,55 +130,18 @@
 
         <!-- Body copy -->
         <h1>Your Transportation Access Pass (TAP) CharlieCard is on its way!</h1>
-        <p>
-          Your Transportation Access Pass (TAP) CharlieCard will arrive via USPS in 3-5 business days to
-          your mailing address.
-        </p>
+        <p>Your Transportation Access Pass (TAP) CharlieCard will arrive via USPS in 3-5 business days to your mailing address.</p>
 
         <h2>About your card</h2>
-
         <ul>
-          <li>
-            You can use your 
-            <a href="https://www.mbta.com/fares/reduced/transportation-access-pass">Transportation Access Pass (TAP) CharlieCard</a>
-            for:
-
-            <ul>
-              <li>
-                <strong>50% off one-ways fares</strong> on bus, subway,
-                Express Bus, Commuter Rail, and ferry.
-              </li>
-              <li>
-                <strong>$30 monthly passes</strong> or <strong>$10 7-day passes</strong> for unlimited bus, subway,
-                Commuter Rail Zone 1A, and Inner Harbor Ferry rides.
-              </li>
-              <li>
-                <a href="https://www.mbta.com/fares/reduced#passes">Discounted monthly passes</a> for Express Bus, Commuter Rail, and ferry.
-              </li>
-            </ul>
-            
-          </li>
-          <li>
-            If your card is damaged, lost, or stolen, you can request a
-            replacement card using the online application or by calling
-            Customer Support at 617-222-3200.
-          </li>
-          <li>
-            If your card was a renewal or replacement, your monthly pass and
-            balance from your old card will be automatically transferred to
-            your new card.
-          </li>
-          <li>
-            <strong><span class="formElementOnEditor" contenteditable="false" data-row-name="element206-hiddenTitle">Generated Content: Card Duration Text<em><small>(no title)</small></em></span></strong>
-          </li>
+          <li>Learn <a href="https://www.mbta.com/fares/reduced/transportation-access-pass">how to use your card</a>.</li>
+          <li>If your card is damaged, lost, or stolen, you can request a replacement card using the online application or by calling Customer Support at 617-222-3200.</li>
+          <li>If your card was a renewal or replacement, your monthly pass and balance from your old card will be automatically transferred to your new card.</li>
+          <li><strong><span class="formElementOnEditor" contenteditable="false" data-row-name="element206-hiddenTitle">Generated Content: Card Duration Text<em><small>(no title)</small></em></span></strong></li>
         </ul>
 
         <h2>Questions?</h2>
-        <p>
-          Contact
-          <a href="https://www.mbta.com/customer-support">Customer Support using their online form</a>
-          or call the numbers below.
-        </p>
+        <p>Contact <a href="https://www.mbta.com/customer-support">Customer Support using their online form</a> or call the numbers below.</p>
         <p>
           Monday &ndash; Friday: 6:30 AM &ndash; 8 PM<br />
           Saturday &ndash; Sunday: 8 AM &ndash; 4 PM
@@ -190,13 +153,11 @@
           TTY: <a href="tel:617-222-5146">617-222-5146</a>
         </p>
 
-        <h2>Sign up to receive MBTA accessibility emails</h2>
+        <h2>Do you want to learn more about the T?</h2>
+        <p>Our Travel Trainers at the <a href="https://www.mbta.com/accessibility/mbta-mobility-center">Mobility Center</a> are ready to assist. To learn how to ride the T safely and independently, plan your trip, use your mobile apps, and access other transit services, contact <a href="tel:617-337-2756">617-337-2756</a> or <a href="mailto:howtotravel@mbta.com">howtotravel@mbta.com</a>.</p>
 
-        <p>
-          Join the MBTA's Department of System-wide Accessibility email list
-          to get periodic updates on the work we're doing and alerts for
-          upcoming meetings.
-        </p>
+        <h2>Sign up to receive MBTA accessibility emails</h2>
+        <p>Join the MBTA's Department of System-wide Accessibility email list to get periodic updates on the work we're doing and alerts for upcoming meetings.</p>
 
         <!-- Button -->
         <table border="0" cellspacing="0" cellpadding="0" role="presentation">
@@ -229,8 +190,7 @@
     <!-- Footer -->
     <footer>
       <p style="margin-top: 24px">
-        <a href="https://www.mbta.com/policies/privacy-policy#4.4" target="_blank" style="color: #165c96">Privacy
-          policy</a>
+        <a href="https://www.mbta.com/policies/privacy-policy#4.4" target="_blank" style="color: #165c96">Privacy policy</a>
       </p>
     </footer>
   </div>

--- a/assets/tap_html/emails/approved_by_mail_emails/approved-by-mail-portuguese.html
+++ b/assets/tap_html/emails/approved_by_mail_emails/approved-by-mail-portuguese.html
@@ -130,33 +130,15 @@
 
         <!-- Body copy -->
         <h1>O cartão CharlieCard do Transportation Access Pass (TAP) está a caminho!</h1>
-
         <p>O cartão CharlieCard do Transportation Access Pass (TAP) chegará pelo correio dentro de 3 a 5 dias úteis no endereço fornecido.</p>
 
         <h2>Sobre o cartão</h2>
-
         <ul>
-          <li>Pode usar o <a href="https://www.mbta.com/fares/reduced/transportation-access-pass">CharlieCard do Transportation Access Pass (TAP)</a> para:
-            <ul>
-              <li>
-                <strong>50% de desconto nas tarifas de ida</strong> e volta no ônibus, metrô, ônibus expresso, trem e balsa.
-              </li>
-              <li>
-                <strong>$30 de passes mensais</strong> ou <strong>$10 de passes de 7 dias</strong> para viagens ilimitadas de ônibus, metrô, Commuter Rail Zone 1A e Inner Harbor Ferry.
-              </li>
-              <li>
-                <a href="https://www.mbta.com/fares/reduced#passes">Passes mensais com desconto</a> para ônibus expresso, trem e balsa. 
-              </li>
-            </ul>
-            
-          </li>
+          <li>Saiba <a href="https://www.mbta.com/fares/reduced/transportation-access-pass">como usar o seu cartão</a>.</li>
           <li>Se o cartão ficar danificado, for perdido ou roubado, solicite um outro cartão pelo modo on-line ou ligando para o Atendimento ao cliente no número 617-222-3200.</li>
           <li>Se o cartão foi renovado ou substituído, o passe mensal e o saldo do cartão antigo serão transferidos automaticamente para o novo cartão.</li>
-          <li>
-            <strong><span class="formElementOnEditor" contenteditable="false" data-row-name="element206-hiddenTitle">Generated Content: Card Duration Text<em><small>(no title)</small></em></span></strong>
-          </li>
+          <li><strong><span class="formElementOnEditor" contenteditable="false" data-row-name="element206-hiddenTitle">Generated Content: Card Duration Text<em><small>(no title)</small></em></span></strong></li>
         </ul>
-
 
         <h2>Dúvidas?</h2>
 
@@ -173,8 +155,10 @@
           TTY: <a href="tel:617-222-5146">617-222-5146</a>
         </p>
 
-        <h2>Inscreva-se para receber e-mails de acessibilidade da MBTA</h2>
+        <h2>Gostaria de saber mais sobre o T?</h2>
+        <p>Nossos Travel Trainers (orientadores de viagens) no <a href="https://www.mbta.com/accessibility/mbta-mobility-center">Mobility Center</a> (Centro de Mobilidade) estão prontos para ajudar. Para saber como usar o T de forma segura e independente, planejar a sua viagem, usar os seus aplicativos móveis e ter acesso a outros serviços de trânsito, entre em contato pelo telefone <a href="tel:617-337-2756">617-337-2756</a> ou pelo e-mail <a href="mailto:howtotravel@mbta.com">howtotravel@mbta.com</a>.</p>
 
+        <h2>Inscreva-se para receber e-mails de acessibilidade da MBTA</h2>
         <p>Faça parte da lista de e-mails do Departamento de Acessibilidade da MBTA para obter atualizações periódicas sobre o trabalho que estamos realizando e alertas para as próximas reuniões.</p>
 
         <!-- Button -->

--- a/assets/tap_html/emails/approved_by_mail_emails/approved-by-mail-spanish.html
+++ b/assets/tap_html/emails/approved_by_mail_emails/approved-by-mail-spanish.html
@@ -130,31 +130,14 @@
 
         <!-- Body copy -->
         <h1>¡Su tarjeta CharlieCard del Pase de Acceso al Transporte (TAP) está en camino!</h1>
-        
         <p>Su tarjeta CharlieCard del Pase de Acceso al Transporte (TAP) llegará vía USPS en 3-5 días laborables a su dirección postal.</p>
 
         <h2>Sobre su tarjeta</h2>
-
         <ul>
-          <li>
-            Puede usar su <a href="https://www.mbta.com/fares/reduced/transportation-access-pass">CharlieCard con el Pase de Acceso al Transporte (TAP)</a> para:
-            <ul>
-              <li>
-                <strong>descuentos del 50% en trayectos de una dirección</strong> en autobús, metro, autobús exprés, tren suburbano y ferry.
-              </li>
-              <li>
-                <strong>pases mensuales de $30 o pases de 7 días de $10</strong> para una cantidad ilimitada de trayectos en autobús, metro, tren suburbano de la Zona 1A y ferry dentro de la bahía.
-              </li>
-              <li>
-                <a href="https://www.mbta.com/fares/reduced#passes">descuentos en los pases mensuales</a> para el autobús exprés, el tren suburbano y el ferry.
-              </li>
-            </ul>
-          </li>
+          <li>Aprenda <a href="https://www.mbta.com/fares/reduced/transportation-access-pass">cómo usar la tarjeta</a>.</li>
           <li>Si su tarjeta se daña, se pierde o se la roban, puede solicitar una tarjeta de reemplazo utilizando la solicitud en línea o llamando al servicio de atención al cliente al 617-222-3200.</li>
           <li>Si su tarjeta era una renovación o un reemplazo, el pase mensual y el saldo de su antigua tarjeta se transferirán automáticamente a su nueva tarjeta.</li>
-          <li>
-            <strong><span class="formElementOnEditor" contenteditable="false" data-row-name="element206-hiddenTitle">Generated Content: Card Duration Text<em><small>(no title)</small></em></span></strong>
-          </li>
+          <li><strong><span class="formElementOnEditor" contenteditable="false" data-row-name="element206-hiddenTitle">Generated Content: Card Duration Text<em><small>(no title)</small></em></span></strong></li>
         </ul>
 
         <h2>¿Preguntas?</h2>
@@ -164,12 +147,10 @@
           <a href="https://www.mbta.com/customer-support">Servicio de atención al cliente a través de 
           su formulario en línea</a> o llame al número que aparece a continuación.
         </p>
-
         <p>
           Lunes &ndash; viernes: 6:30 AM &ndash; 8 PM<br />
           Sábado &ndash; domingo: 8 AM &ndash; 4 PM
         </p>
-
         <p>
           <strong>Línea directa principal: </strong>
           <a href="tel:617-222-3200">617-222-3200</a><br />
@@ -177,12 +158,11 @@
           Teletipo TTY: <a href="tel:617-222-5146">617-222-5146</a>
         </p>
 
-        <h2>Inscríbase para recibir correos electrónicos sobre la accesibilidad de la MBTA</h2>
+        <h2>¿Quiere saber más sobre la T?</h2>
+        <p>Nuestros entrenadores de viaje en el <a href="https://www.mbta.com/accessibility/mbta-mobility-center">Mobility Center</a> (Centro de Movilidad) están dispuestos a ayudarle. Para saber cómo viajar en la T de forma segura e independiente, planificar su viaje, utilizar las aplicaciones móviles y acceder a otros servicios de tránsito, póngase en contacto con el <a href="tel:617-337-2756">617-337-2756</a> o escriba a <a href="mailto:howtotravel@mbta.com">howtotravel@mbta.com</a>.</p>
 
-        <p>
-          Únase a la lista de correo electrónico del Departamento de Accesibilidad del Sistema de la MBTA para recibir
-          actualizaciones periódicas sobre el trabajo que estamos realizando y alertas sobre las próximas reuniones.
-        </p>
+        <h2>Inscríbase para recibir correos electrónicos sobre la accesibilidad de la MBTA</h2>
+        <p>Únase a la lista de correo electrónico del Departamento de Accesibilidad del Sistema de la MBTA para recibir actualizaciones periódicas sobre el trabajo que estamos realizando y alertas sobre las próximas reuniones.</p>
 
         <!-- Button -->
         <table border="0" cellspacing="0" cellpadding="0" role="presentation">

--- a/assets/tap_html/emails/approved_in_store_emails/approved-in-store-chinese-simplified.html
+++ b/assets/tap_html/emails/approved_in_store_emails/approved-in-store-chinese-simplified.html
@@ -131,33 +131,36 @@
         <!-- Body copy -->
         <h1>你的交通乘车通票 (TAP) 查里卡已经准备好！</h1>
         <p>前往位于Downtown Crossing车站红线和橙线之间地下大厅内的查理卡出售店：7 Chauncy Street, Boston, MA 02111。</p>
-
         <p>要从车站外进入查理卡出售店，请使用101 Arch Street大楼内的无障碍电梯。</p>
-
-        <p>
-          <a href="https://www.mbta.com/fares/charliecard-store">查看查理卡出售店营业时间</a>
-        </p>
-
+        <p><a href="https://www.mbta.com/fares/charliecard-store">查看查理卡出售店营业时间</a></p>
         <p>领取你的卡不需要预约。</p>
 
-        <h2>有问题吗?</h2>
+        <h2>关于你的卡</h2>
+        <ul>
+          <li>了解<a href="https://www.mbta.com/fares/reduced/transportation-access-pass">如何使用你的卡</a>。</li>
+          <li>如果你的卡损坏、丢失或被盗，你可以使用网上申请或致打电话给客户支持617-222-3200申请补发卡。</li>
+          <li>如果你的卡是续期或更换卡，你的月票和旧卡中的余额将自动转移到你的新卡中。</li>
+          <li><strong><span class="formElementOnEditor" contenteditable="false" data-row-name="element206-hiddenTitle">Generated Content: Card Duration Text<em><small>(no title)</small></em></span></strong></li>
+        </ul>
 
+        <h2>有问题吗?</h2>
         <p>
           请联系<a href="https://www.mbta.com/customer-support">客户支持 (使用网上表格) </a>
           或给下列号码打电话。
         </p>
-
         <p>
           周一 &ndash; 周五: 早6:30 &ndash; 晚8点<br />
           周六 &ndash; 周日: 早8点 &ndash; 下午4点
         </p>
-
         <p>
           <strong>主热线: </strong>
           <a href="tel:617-222-3200">617-222-3200</a><br />
           免费电话: <a href="tel:800-392-6100">800-392-6100</a><br />
           TTY: <a href="tel:617-222-5146">617-222-5146</a>
         </p>
+
+        <h2>你是否想了解更多有关T的信息？</h2>
+        <p>我们的移动中心（<a href="https://www.mbta.com/accessibility/mbta-mobility-center">Mobility Center</a>）交通培训员随时准备为你提供帮助。要了解如何安全、独立地乘坐T、计划出行、使用移动应用程序以及获得其他交通服务，请联系<a href="tel:617-337-2756">617-337-2756</a>或<a href="mailto:howtotravel@mbta.com">howtotravel@mbta.com</a>。</p>
 
         <h2>注册以接收有关MBTA无障碍性的电子邮件</h2>
         <p>加入MBTA的系统范围内无障碍性部门的电子邮件名单，以获取有关我们正在开展的工作的定期更新以及即将举行的会议通知。</p>

--- a/assets/tap_html/emails/approved_in_store_emails/approved-in-store-english.html
+++ b/assets/tap_html/emails/approved_in_store_emails/approved-in-store-english.html
@@ -130,29 +130,21 @@
 
         <!-- Body copy -->
         <h1>Your Transportation Access Pass (TAP) CharlieCard is ready!</h1>
-        <p>
-          Visit the CharlieCard Store, located at Downtown Crossing Station,
-          on the underground concourse between the Red and Orange lines: 7
-          Chauncy Street Boston, MA 02111.
-        </p>
-
-        <p>
-          To access the CharlieCard Store from outside the station, use the
-          accessible elevator inside the 101 Arch Street building.
-        </p>
-
-        <p>
-          <a href="https://www.mbta.com/fares/charliecard-store">View CharlieCard Store hours</a>
-        </p>
-
+        <p>Visit the CharlieCard Store, located at Downtown Crossing Station, on the underground concourse between the Red and Orange lines: 7 Chauncy St Boston, MA 02111.</p>
+        <p>To access the CharlieCard Store from outside the station, use the accessible elevator inside the 101 Arch Street building.</p>
+        <p><a href="https://www.mbta.com/fares/charliecard-store">View CharlieCard Store hours</a></p>
         <p>You do not need an appointment to pick up your card.</p>
 
+        <h2>About your card</h2>
+        <ul>
+          <li>Learn <a href="https://www.mbta.com/fares/reduced/transportation-access-pass">how to use your card</a>.</li>
+          <li>If your card is damaged, lost, or stolen, you can request a replacement card using the online application or by calling Customer Support at 617-222-3200.</li>
+          <li>If your card was a renewal or replacement, your monthly pass and balance from your old card will be automatically transferred to your new card.</li>
+          <li><strong><span class="formElementOnEditor" contenteditable="false" data-row-name="element206-hiddenTitle">Generated Content: Card Duration Text<em><small>(no title)</small></em></span></strong></li>
+        </ul>
+
         <h2>Questions?</h2>
-        <p>
-          Contact
-          <a href="https://www.mbta.com/customer-support">Customer Support using their online form</a>
-          or call the number below.
-        </p>
+        <p>Contact <a href="https://www.mbta.com/customer-support">Customer Support using their online form</a> or call the number below.</p>
         <p>
           Monday &ndash; Friday: 6:30 AM &ndash; 8 PM<br />
           Saturday &ndash; Sunday: 8 AM &ndash; 4 PM
@@ -164,12 +156,11 @@
           TTY: <a href="tel:617-222-5146">617-222-5146</a>
         </p>
 
+        <h2>Do you want to learn more about the T?</h2>
+        <p>Our Travel Trainers at the <a href="https://www.mbta.com/accessibility/mbta-mobility-center">Mobility Center</a> are ready to assist. To learn how to ride the T safely and independently, plan your trip, use your mobile apps, and access other transit services, contact <a href="tel:617-337-2756">617-337-2756</a> or <a href="mailto:howtotravel@mbta.com">howtotravel@mbta.com</a>.</p>
+
         <h2>Sign up to receive MBTA accessibility emails</h2>
-        <p>
-          Join the MBTA's Department of System-wide Accessibility email list
-          to get periodic updates on the work we're doing and alerts for
-          upcoming meetings.
-        </p>
+        <p>Join the MBTA's Department of System-wide Accessibility email list to get periodic updates on the work we're doing and alerts for upcoming meetings.</p>
 
         <!-- Button -->
         <table border="0" cellspacing="0" cellpadding="0" role="presentation">
@@ -202,8 +193,7 @@
     <!-- Footer -->
     <footer>
       <p style="margin-top: 24px">
-        <a href="https://www.mbta.com/policies/privacy-policy#4.4" target="_blank" style="color: #165c96">Privacy
-          policy</a>
+        <a href="https://www.mbta.com/policies/privacy-policy#4.4" target="_blank" style="color: #165c96">Privacy policy</a>
       </p>
     </footer>
   </div>

--- a/assets/tap_html/emails/approved_in_store_emails/approved-in-store-portuguese.html
+++ b/assets/tap_html/emails/approved_in_store_emails/approved-in-store-portuguese.html
@@ -139,6 +139,15 @@
 
         <p>Não é necessário agendar a retirada do cartão.</p>
 
+        <h2>Sobre o cartão</h2>
+
+        <ul>
+          <li>Saiba <a href="https://www.mbta.com/fares/reduced/transportation-access-pass">como usar o seu cartão</a>.</li>
+          <li>Se o cartão ficar danificado, for perdido ou roubado, solicite um outro cartão pelo modo on-line ou ligando para o Atendimento ao cliente no número 617-222-3200.</li>
+          <li>Se o cartão foi renovado ou substituído, o passe mensal e o saldo do cartão antigo serão transferidos automaticamente para o novo cartão.</li>
+          <li><strong><span class="formElementOnEditor" contenteditable="false" data-row-name="element206-hiddenTitle">Generated Content: Card Duration Text<em><small>(no title)</small></em></span></strong></li>
+        </ul>
+
         <h2>Dúvidas?</h2>
 
         <p>Contate o <a href="https://www.mbta.com/customer-support">Atendimento ao cliente usando o formulário on-line</a> ou ligue para os números abaixo.</p>
@@ -154,8 +163,10 @@
           TTY: <a href="tel:617-222-5146">617-222-5146</a>
         </p>
 
-        <h2>Inscreva-se para receber e-mails de acessibilidade da MBTA</h2>
-        
+        <h2>Gostaria de saber mais sobre o T?</h2>
+        <p>Nossos Travel Trainers (orientadores de viagens) no <a href="https://www.mbta.com/accessibility/mbta-mobility-center">Mobility Center</a> (Centro de Mobilidade) estão prontos para ajudar. Para saber como usar o T de forma segura e independente, planejar a sua viagem, usar os seus aplicativos móveis e ter acesso a outros serviços de trânsito, entre em contato pelo telefone <a href="tel:617-337-2756">617-337-2756</a> ou pelo e-mail <a href="mailto:howtotravel@mbta.com">howtotravel@mbta.com</a>.</p>
+
+        <h2>Inscreva-se para receber e-mails de acessibilidade da MBTA</h2> 
         <p>Faça parte da lista de e-mails do Departamento de Acessibilidade da MBTA para obter atualizações periódicas sobre o trabalho que estamos realizando e alertas para as próximas reuniões.</p>
 
         <!-- Button -->

--- a/assets/tap_html/emails/approved_in_store_emails/approved-in-store-spanish.html
+++ b/assets/tap_html/emails/approved_in_store_emails/approved-in-store-spanish.html
@@ -135,11 +135,17 @@
 
         <p>Para acceder a la Tienda CharlieCard desde el exterior de la estación, utilice el ascensor accesible que se encuentra en el interior del edificio de la calle Arch 101.</p>
 
-        <p>
-          <a href="https://www.mbta.com/fares/charliecard-store">Ver el horario de la Tienda CharlieCard</a>
-        </p>
+        <p><a href="https://www.mbta.com/fares/charliecard-store">Ver el horario de la Tienda CharlieCard</a></p>
 
         <p>No necesita una cita para recoger su tarjeta.</p>
+
+        <h2>Sobre su tarjeta</h2>
+        <ul>
+          <li>Aprenda <a href="https://www.mbta.com/fares/reduced/transportation-access-pass">cómo usar la tarjeta</a>.</li>
+          <li>Si su tarjeta se daña, se pierde o se la roban, puede solicitar una tarjeta de reemplazo utilizando la solicitud en línea o llamando al servicio de atención al cliente al 617-222-3200.</li>
+          <li>Si su tarjeta era una renovación o un reemplazo, el pase mensual y el saldo de su antigua tarjeta se transferirán automáticamente a su nueva tarjeta.</li>
+          <li><strong><span class="formElementOnEditor" contenteditable="false" data-row-name="element206-hiddenTitle">Generated Content: Card Duration Text<em><small>(no title)</small></em></span></strong></li>
+        </ul>
 
         <h2>¿Preguntas?</h2>
 
@@ -157,8 +163,10 @@
           Teletipo TTY: <a href="tel:617-222-5146">617-222-5146</a>
         </p>
 
-        <h2>Inscríbase para recibir correos electrónicos sobre la accesibilidad de la MBTA</h2>
+        <h2>¿Quiere saber más sobre la T?</h2>
+        <p>Nuestros entrenadores de viaje en el <a href="https://www.mbta.com/accessibility/mbta-mobility-center">Mobility Center</a> (Centro de Movilidad) están dispuestos a ayudarle. Para saber cómo viajar en la T de forma segura e independiente, planificar su viaje, utilizar las aplicaciones móviles y acceder a otros servicios de tránsito, póngase en contacto con el <a href="tel:617-337-2756">617-337-2756</a> o escriba a <a href="mailto:howtotravel@mbta.com">howtotravel@mbta.com</a>.</p>
 
+        <h2>Inscríbase para recibir correos electrónicos sobre la accesibilidad de la MBTA</h2>
         <p>Únase a la lista de correo electrónico del Departamento de Accesibilidad del Sistema de la MBTA para recibir actualizaciones periódicas sobre el trabajo que estamos realizando y alertas sobre las próximas reuniones.</p>
 
         <!-- Button -->

--- a/assets/tap_html/form_elements/tap-form-fields.html
+++ b/assets/tap_html/form_elements/tap-form-fields.html
@@ -1366,7 +1366,6 @@
 <!-- EMAIL NOTIFICATION | FORM ELEMENT 279 | * ADMIN ONLY * -->
 <p>The applicant will receive an email asking them to visit the CharlieCard Store to pick up their card or call Customer Support to update their mailing address.</p>
 
-
 <!-- CONTACT APPLICATION VIA PHONE NOTIFICATION | FORM ELEMENT 280 | * ADMIN ONLY * -->
 <div style="background-image: initial; background-attachment: initial; background-color: rgba(238, 238, 238, 1); border: 1px solid rgba(204, 204, 204, 1); padding: 5px 10px">
     <span style="font-size: 11pt"><span style="line-height: 107%"><i class="fa fa-phone" aria-hidden="true"></i> Please contact the applicant via phone at <span class="formElementOnEditor" contenteditable="false" data-row-name="element19-hiddenTitle">Contact Information: Phone number (optional)<em><small>(no title)</small></em></span>.</span></span>
@@ -1374,3 +1373,97 @@
 
 <!-- NO EMAIL OR PHONE NOTIFICATION | FORM ELEMENT 281 | * ADMIN ONLY * -->
 <p>The applicant did not provide their phone number or email address.</p>
+
+<!-- NAME CHANGE REVIEW APPLICATION CALLOUT | FORM ELEMENT 203 * ADMIN ONLY * -->
+<div style="background-image: initial; background-attachment: initial; background-color: rgba(238, 238, 238, 1); border: 1px solid rgba(204, 204, 204, 1); padding: 5px 10px">
+    <span style="font-size: 11pt"><span style="line-height: 107%"><i class="fa fa-id-card-o" aria-hidden="true"></i> The applicant's name has changed since their last card.</span></span>
+</div>
+
+<!-- NAME CHANGE PREPARE CARD CALLOUT | FORM ELEMENT 204 * ADMIN ONLY * -->
+<div style="background-image: initial; background-attachment: initial; background-color: rgba(238, 238, 238, 1); border: 1px solid rgba(204, 204, 204, 1); padding: 5px 10px">
+    <span style="font-size: 11pt"><span style="line-height: 107%"><i class="fa fa-id-card-o" aria-hidden="true"></i> The applicant's name has changed since their last card. <strong><span class="formElementOnEditor" contenteditable="false" data-row-name="element283-hiddenTitle">Personal Information: Name on previous card (require...<em><small>(no title)</small></em></span></strong> is recorded as the name on the prior card.</span></span>
+</div>
+
+
+<!-- CHARLIECARD STORE TEMP LOCATION | FORM ELEMENT 40 -->
+<!-- English -->
+<div class="info-alert-item">
+    <div class="info-alert-item__icon" aria-hidden="true">
+        <span class="notranslate fa fa-exclamation-circle fa-2x"></span>
+    </div>
+    <div class="info-alert-item__top">
+        <div role="alert" class="info-alert-item__top-text-container">
+            <div class="info-alert-item__effect">
+                As of Thursday, July 27, 2023, the CharlieCard Store is temporarily relocating to the State Transportation Building
+            </div>
+            <p>Due to maintenance issues, the CharlieCard Store is temporarily relocating. Services will be available in Conference Room 6, on the second floor of the State Transportation Building, located at <a href="https://www.mbta.com/trip-planner/to/%2010%20park%20plaza" target="_blank">10 Park Plaza <i class="fa fa-external-link" aria-hidden="true"></i></a>, until further notice.</p>
+            <p>For more information during this time, you can visit the <a href="https://www.mbta.com/fares/charliecard-store" target="_blank">MBTA website <i class="fa fa-external-link" aria-hidden="true"></i></a>.</p>
+        </div>
+    </div>
+</div>
+
+<!-- Spanish -->
+<div class="info-alert-item">
+    <div class="info-alert-item__icon" aria-hidden="true">
+        <span class="notranslate fa fa-exclamation-circle fa-2x"></span>
+    </div>
+    <div class="info-alert-item__top">
+        <div role="alert" class="info-alert-item__top-text-container">
+            <div class="info-alert-item__effect">
+                A partir del jueves 27 de julio de 2023, la CharlieCard Store se trasladará temporalmente al Edificio de Transporte Estatal
+            </div>
+            <p>Debido a problemas de mantenimiento, CharlieCard Store se mudará temporalmente. Los servicios estarán disponibles en la Sala de conferencias 6, en el segundo piso del State Transportation Building, ubicado en <a href="https://www.mbta.com/trip-planner/to/%2010%20park%20plaza" target="_blank">10 Park Plaza <i class="fa fa-external-link" aria-hidden="true"></i></a>, hasta nuevo aviso.</p>
+            <p>Para obtener más información durante este tiempo, puede visitar el <a href="https://www.mbta.com/fares/charliecard-store" target="_blank">sitio web de MBTA <i class="fa fa-external-link" aria-hidden="true"></i></a>.</p>
+        </div>
+    </div>
+</div>
+
+<!-- Portuguese -->
+<div class="info-alert-item">
+    <div class="info-alert-item__icon" aria-hidden="true">
+        <span class="notranslate fa fa-exclamation-circle fa-2x"></span>
+    </div>
+    <div class="info-alert-item__top">
+        <div role="alert" class="info-alert-item__top-text-container">
+            <div class="info-alert-item__effect">
+                A partir de quinta-feira, 27 de julho de 2023, a CharlieCard Store será temporariamente transferida para o State Transportation Building
+            </div>
+            <p>Devido a problemas de manutenção, a CharlieCard Store está se mudando temporariamente. Os serviços estarão disponíveis na Sala de Conferências 6, no segundo andar do State Transportation Building, localizado no <a href="https://www.mbta.com/trip-planner/to/%2010%20park%20plaza" target="_blank">10 Park Plaza <i class="fa fa-external-link" aria-hidden="true"></i></a>, até novo aviso.</p>
+            <p>Para obter mais informações durante esse período, você pode visitar o <a href="https://www.mbta.com/fares/charliecard-store" target="_blank">site do MBTA <i class="fa fa-external-link" aria-hidden="true"></i></a>.</p>
+        </div>
+    </div>
+</div>
+
+
+<!-- Chinese Simplified -->
+<div class="info-alert-item">
+    <div class="info-alert-item__icon" aria-hidden="true">
+        <span class="notranslate fa fa-exclamation-circle fa-2x"></span>
+    </div>
+    <div class="info-alert-item__top">
+        <div role="alert" class="info-alert-item__top-text-container">
+            <div class="info-alert-item__effect">
+                自 2023 年 7 月 27 日星期四起，CharlieCard Store暂时搬迁至国家交通大楼
+            </div>
+            <p>由于维护问题，CharlieCard Store暂时搬迁。服务将在位于<a href="https://www.mbta.com/trip-planner/to/%2010%20park%20plaza" target="_blank">10 Park Plaza<i class="fa fa-external-link" aria-hidden="true"></i></a>的国家交通大厦二楼第 6 号会议室提供，直至另行通知。</p>
+            <p>在此期间欲了解更多信息，您可以访问<a href="https://www.mbta.com/fares/charliecard-store" target="_blank">MBTA网站<i class="fa fa-external-link" aria-hidden="true"></i></a>。</p>
+        </div>
+    </div>
+</div>
+
+
+<!-- Chinese Traditional -->
+<div class="info-alert-item">
+    <div class="info-alert-item__icon" aria-hidden="true">
+        <span class="notranslate fa fa-exclamation-circle fa-2x"></span>
+    </div>
+    <div class="info-alert-item__top">
+        <div role="alert" class="info-alert-item__top-text-container">
+            <div class="info-alert-item__effect">
+                自2023年7月27日星期四起，CharlieCard Store暫時搬遷至國家交通大廈
+            </div>
+            <p>由於維護問題，CharlieCard Store暫時搬遷。服務將在位於<a href="https://www.mbta.com/trip-planner/to/%2010%20park%20plaza" target="_blank">10 Park Plaza <i class="fa fa-external-link" aria-hidden="true"></i></a>國家交通大樓二樓的第 6 號會議室提供，直至另行通知。</p>
+            <p>在此期間，您可以訪問<a href="https://www.mbta.com/fares/charliecard-store" target="_blank">MBTA網站<i class="fa fa-external-link" aria-hidden="true"></i></a>了解更多信息。</p>
+        </div>
+    </div>
+</div>

--- a/assets/tap_html/pdfs/in_store_slips/in-store-slip-chinese-simplified.html
+++ b/assets/tap_html/pdfs/in_store_slips/in-store-slip-chinese-simplified.html
@@ -28,7 +28,17 @@
         <span class="formElementOnEditor" contenteditable="false" data-row-name="element202-hiddenTitle">Prepare Card: Stored value transfer (require...<em><small>(no title)</small></em></span>
      </p>
 
-    <p>&nbsp;</p>
+     <p>&nbsp;</p>
+
+     <h2 style="font-size: 20.8px; font-family: Arial; font-weight: 700; margin-left: 16px; padding: 0;">
+         <strong>卡片时长</strong>
+     </h2>
+ 
+     <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;">
+         <span class="formElementOnEditor" contenteditable="false" data-row-name="element206-hiddenTitle">Generated Content: Card Duration Text<em><small>(no title)</small></em></span>
+     </p>
+ 
+     <p>&nbsp;</p>
 
     <h2 style="font-size: 20.8px; font-family: Arial; font-weight: 700; margin-left: 16px; padding: 0;">
         <strong>有问题吗?</strong></h2>

--- a/assets/tap_html/pdfs/in_store_slips/in-store-slip-english.html
+++ b/assets/tap_html/pdfs/in_store_slips/in-store-slip-english.html
@@ -23,8 +23,17 @@
     </p>
 
     <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;"><strong>Stored value transfer</strong><br />
-        <span class="formElementOnEditor" contenteditable="false" data-row-name="element202-hiddenTitle">Prepare Card:
-            Stored value transfer (require...<em><small>(no title)</small></em></span>
+        <span class="formElementOnEditor" contenteditable="false" data-row-name="element202-hiddenTitle">Prepare Card: Stored value transfer (require...<em><small>(no title)</small></em></span>
+    </p>
+
+    <p>&nbsp;</p>
+
+    <h2 style="font-size: 20.8px; font-family: Arial; font-weight: 700; margin-left: 16px; padding: 0;">
+        <strong>Card duration</strong>
+    </h2>
+
+    <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;">
+        <span class="formElementOnEditor" contenteditable="false" data-row-name="element206-hiddenTitle">Generated Content: Card Duration Text<em><small>(no title)</small></em></span>
     </p>
 
     <p>&nbsp;</p>

--- a/assets/tap_html/pdfs/in_store_slips/in-store-slip-portuguese.html
+++ b/assets/tap_html/pdfs/in_store_slips/in-store-slip-portuguese.html
@@ -1,16 +1,12 @@
 <div style="margin:0; padding: 0"><img src="https://mbta.prod.simpligov.com/prod/portal/file/51d7628117ce4c0c9cb0000188390b62.png?t=1633355953036" style="width: 335.4px; height: 62.4px; margin-left: 8px; margin-top: 6px" />
     <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">MBTA TAP CharlieCard</p>
-
     <p style="font-size: 16px; font-family: Arial; text-align: right; margin: 0; padding: 0;">Order date (data do pedido): <span class="formElementOnEditor" contenteditable="false" data-row-name="element94-hiddenTitle">Prepare Card: Date card prepared<em><small>(no title)</small></em></span></p>
-
     <p style="font-size: 16px; font-family: Arial; margin: 43px 0 2px 62px; padding: 0;"><span class="formElementOnEditor" contenteditable="false" data-row-name="element15-hiddenTitle">Personal Information: First name (required)<em><small>(no title)</small></em></span>&nbsp;<span class="formElementOnEditor" contenteditable="false" data-row-name="element16-hiddenTitle">Personal Information: Last name (required)<em><small>(no title)</small></em></span></p>
-
     <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;">7 Chauncy Street</p>
-
     <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;">Boston, MA 02111</p>
 
     <hr style="margin: 56px 0 0 0; padding: 0;" />
-    <h1 style="font-size: 27.3px; font-family: Arial; font-weight: 700; margin-top: 48px; margin-left: 16px; padding: 0;">Cartão CharlieCard do Transportation access pass (TAP)</h1>
+    <h1 style="font-size: 27.3px; font-family: Arial; font-weight: 700; margin-top: 48px; margin-left: 16px; padding: 0;">Cartão CharlieCard do TAP</h1>
 
     <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;"><strong>Número de série</strong><br />
         <span class="formElementOnEditor" contenteditable="false" data-row-name="element90-hiddenTitle">Prepare Card: New serial card number (requir...<em><small>(no title)</small></em></span>
@@ -28,7 +24,17 @@
         <span class="formElementOnEditor" contenteditable="false" data-row-name="element202-hiddenTitle">Prepare Card: Stored value transfer (require...<em><small>(no title)</small></em></span>
      </p>
 
-    <p>&nbsp;</p>
+     <p>&nbsp;</p>
+
+     <h2 style="font-size: 20.8px; font-family: Arial; font-weight: 700; margin-left: 16px; padding: 0;">
+         <strong>Duração do cartão</strong>
+     </h2>
+ 
+     <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;">
+         <span class="formElementOnEditor" contenteditable="false" data-row-name="element206-hiddenTitle">Generated Content: Card Duration Text<em><small>(no title)</small></em></span>
+     </p>
+ 
+     <p>&nbsp;</p>
 
     <h2 style="font-size: 20.8px; font-family: Arial; font-weight: 700; margin-left: 16px; padding: 0;">Dúvidas?</h2>
 

--- a/assets/tap_html/pdfs/in_store_slips/in-store-slip-spanish.html
+++ b/assets/tap_html/pdfs/in_store_slips/in-store-slip-spanish.html
@@ -12,7 +12,7 @@
     <p style="font-size: 16px; font-family: Arial; margin: 0 0 2px 62px; padding: 0;">Boston, MA 02111</p>
 
     <hr style="margin: 56px 0 0 0; padding: 0;" />
-    <h1 style="font-size: 27.3px; font-family: Arial; font-weight: 700; margin-top: 48px; margin-left: 16px; padding: 0;">Su CharlieCard con el Pase de Acceso al Transporte (TAP)</h1>
+    <h1 style="font-size: 27.3px; font-family: Arial; font-weight: 700; margin-top: 48px; margin-left: 16px; padding: 0;">Seu TAP CharlieCard</h1>
 
     <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;"><strong>Número de serie</strong><br />
         <span class="formElementOnEditor" contenteditable="false" data-row-name="element90-hiddenTitle">Prepare Card: New serial card number (requir...<em><small>(no title)</small></em></span>
@@ -28,7 +28,17 @@
         <span class="formElementOnEditor" contenteditable="false" data-row-name="element202-hiddenTitle">Prepare Card: Stored value transfer (require...<em><small>(no title)</small></em></span>
      </p>
      
-    <p>&nbsp;</p>
+     <p>&nbsp;</p>
+
+     <h2 style="font-size: 20.8px; font-family: Arial; font-weight: 700; margin-left: 16px; padding: 0;">
+         <strong>Duración de la tarjeta</strong>
+     </h2>
+ 
+     <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;">
+         <span class="formElementOnEditor" contenteditable="false" data-row-name="element206-hiddenTitle">Generated Content: Card Duration Text<em><small>(no title)</small></em></span>
+     </p>
+ 
+     <p>&nbsp;</p>
 
     <h2 style="font-size: 20.8px; font-family: Arial; font-weight: 700; margin-left: 16px; padding: 0;"><strong>¿Preguntas?</strong></h2>
 

--- a/assets/tap_html/pdfs/mailing_slips/mail-slip-chinese-simplified.html
+++ b/assets/tap_html/pdfs/mailing_slips/mail-slip-chinese-simplified.html
@@ -26,7 +26,7 @@
         <span class="formElementOnEditor" contenteditable="false" data-row-name="element90-hiddenTitle">Prepare Card: New serial card number (requir...<em><small>(no title)</small></em></span>
     </p>
 
-    <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;">如果你的卡丢失, 被盗或损坏，你将需要此号码。</p>
+    <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;">如果你的卡丢失、被盗或损坏，你将需要此号码。</p>
 
     <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;">
         <strong>每月转账</strong><br />
@@ -38,6 +38,16 @@
         <span class="formElementOnEditor" contenteditable="false" data-row-name="element202-hiddenTitle">Prepare Card: Stored value transfer (require...<em><small>(no title)</small></em></span>
      </p>
     
+     <p>&nbsp;</p>
+
+     <h2 style="font-size: 20.8px; font-family: Arial; font-weight: 700; margin-left: 16px; padding: 0;">
+         <strong>卡片时长</strong>
+     </h2>
+ 
+     <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;">
+         <span class="formElementOnEditor" contenteditable="false" data-row-name="element206-hiddenTitle">Generated Content: Card Duration Text<em><small>(no title)</small></em></span>
+     </p>
+ 
      <p>&nbsp;</p>
 
      <h2 style="font-size: 20.8px; font-family: Arial; font-weight: 700; margin-left: 16px; padding: 0;">

--- a/assets/tap_html/pdfs/mailing_slips/mail-slip-english.html
+++ b/assets/tap_html/pdfs/mailing_slips/mail-slip-english.html
@@ -39,13 +39,22 @@
     <p>&nbsp;</p>
 
     <h2 style="font-size: 20.8px; font-family: Arial; font-weight: 700; margin-left: 16px; padding: 0;">
+        <strong>Card duration</strong>
+    </h2>
+
+    <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;">
+        <span class="formElementOnEditor" contenteditable="false" data-row-name="element206-hiddenTitle">Generated Content: Card Duration Text<em><small>(no title)</small></em></span>
+    </p>
+
+    <p>&nbsp;</p>
+
+    <h2 style="font-size: 20.8px; font-family: Arial; font-weight: 700; margin-left: 16px; padding: 0;">
         <strong>Questions?</strong>
     </h2>
 
     <p style="font-size: 16px; font-family: Arial; font-weight: 700; margin-left: 16px; padding: 0;">Contact Customer Support</p>
 
-    <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;">Monday &ndash; Friday: 6:30 AM
-        &ndash; 8 PM<br />
+    <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;">Monday &ndash; Friday: 6:30 AM &ndash; 8 PM<br />
         Saturday &ndash; Sunday: 8 AM &ndash; 4 PM</p>
 
     <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;">Main Hotline: 617-222-3200<br />

--- a/assets/tap_html/pdfs/mailing_slips/mail-slip-portuguese.html
+++ b/assets/tap_html/pdfs/mailing_slips/mail-slip-portuguese.html
@@ -22,7 +22,7 @@
     </p>
 
     <hr style="margin: 56px 0 0 0; padding: 0;" />
-    <h1 style="font-size: 27.3px; font-family: Arial; font-weight: 700; margin-top: 48px; margin-left: 16px; padding: 0;">Cartão Charliecard do Transportation access pass (TAP)</h1>
+    <h1 style="font-size: 27.3px; font-family: Arial; font-weight: 700; margin-top: 48px; margin-left: 16px; padding: 0;">Cartão CharlieCard do TAP</h1>
 
     <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;"><strong>Número de série</strong><br />
         <span class="formElementOnEditor" contenteditable="false" data-row-name="element90-hiddenTitle">Prepare Card: New serial card number (requir...<em><small>(no title)</small></em></span>
@@ -40,7 +40,17 @@
         <span class="formElementOnEditor" contenteditable="false" data-row-name="element202-hiddenTitle">Prepare Card: Stored value transfer (require...<em><small>(no title)</small></em></span>
      </p>
 
-    <p>&nbsp;</p>
+     <p>&nbsp;</p>
+
+     <h2 style="font-size: 20.8px; font-family: Arial; font-weight: 700; margin-left: 16px; padding: 0;">
+         <strong>Duração do cartão</strong>
+     </h2>
+ 
+     <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;">
+         <span class="formElementOnEditor" contenteditable="false" data-row-name="element206-hiddenTitle">Generated Content: Card Duration Text<em><small>(no title)</small></em></span>
+     </p>
+ 
+     <p>&nbsp;</p>
 
     <h2 style="font-size: 20.8px; font-family: Arial; font-weight: 700; margin-left: 16px; padding: 0;">
         <strong>Dúvidas?</strong></h2>

--- a/assets/tap_html/pdfs/mailing_slips/mail-slip-spanish.html
+++ b/assets/tap_html/pdfs/mailing_slips/mail-slip-spanish.html
@@ -22,7 +22,7 @@
     </p>
 
     <hr style="margin: 56px 0 0 0; padding: 0;" />
-    <h1 style="font-size: 27.3px; font-family: Arial; font-weight: 700; margin-top: 48px; margin-left: 16px; padding: 0;">Su CharlieCard con el Pase de Acceso al Transporte (TAP)</h1>
+    <h1 style="font-size: 27.3px; font-family: Arial; font-weight: 700; margin-top: 48px; margin-left: 16px; padding: 0;">Seu TAP CharlieCard</h1>
 
     <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;">
         <strong>Número de serie</strong><br />
@@ -39,7 +39,17 @@
         <span class="formElementOnEditor" contenteditable="false" data-row-name="element202-hiddenTitle">Prepare Card: Stored value transfer (require...<em><small>(no title)</small></em></span>
      </p>
 
-    <p>&nbsp;</p>
+     <p>&nbsp;</p>
+
+     <h2 style="font-size: 20.8px; font-family: Arial; font-weight: 700; margin-left: 16px; padding: 0;">
+         <strong>Duración de la tarjeta</strong>
+     </h2>
+ 
+     <p style="font-size: 16px; font-family: Arial; margin-left: 16px; padding: 0;">
+         <span class="formElementOnEditor" contenteditable="false" data-row-name="element206-hiddenTitle">Generated Content: Card Duration Text<em><small>(no title)</small></em></span>
+     </p>
+ 
+     <p>&nbsp;</p>
 
     <h2 style="font-size: 20.8px; font-family: Arial; font-weight: 700; margin-left: 16px; padding: 0;">
         <strong>¿Preguntas?</strong>


### PR DESCRIPTION
This PR includes HTML updates that are consistent with the current copy in SimpliGov, and includes the following changes:

- Adds contact information for the Mobility Center to approval emails.
- Removes specific fare information to match the format used by the Intake form. This will help future-proof all forms in case of fare changes.
- Reformats some HTML. (Some files used Prettier prior to uploading to GitHub. Unfortunately, this caused some form field references to break. These are now fixed.)

No Asana ticket.